### PR TITLE
Move to SOA vertex buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49d9e5a6410cd46e6bea97123cec5ef1cba14274aad26a1835dd3c9b753ae069"
 dependencies = [
+ "bytemuck",
  "version_check",
 ]
 

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -45,21 +45,9 @@ fn create_mesh() -> rend3::datatypes::Mesh {
         22, 21, 20, 20, 23, 22, // back
     ];
 
-    let count = vertex_positions.len();
-
-    let mut mesh = rend3::datatypes::Mesh {
-        vertex_positions: vertex_positions.to_vec(),
-        vertex_normals: vec![glam::Vec3::zero(); count],
-        vertex_uvs: vec![glam::Vec2::zero(); count],
-        vertex_colors: vec![[0; 4]; count],
-        vertex_material_indices: vec![0; count],
-        indices: index_data.to_vec(),
-    };
-
-    // Auto-calculate normals for us
-    mesh.calculate_normals();
-
-    mesh
+    rend3::datatypes::MeshBuilder::new(vertex_positions.to_vec())
+        .with_indices(index_data.to_vec())
+        .build()
 }
 
 fn main() {

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -1,17 +1,9 @@
-fn vertex(pos: [f32; 3]) -> rend3::datatypes::ModelVertex {
-    rend3::datatypes::ModelVertex {
-        position: glam::Vec3::from(pos),
-        // Will be recalculated later.
-        normal: glam::Vec3::unit_y(),
-        // Only used with textures, we don't have one.
-        uv: glam::Vec2::zero(),
-        // We aren't using vertex colors.
-        color: [0, 0, 0, 0],
-    }
+fn vertex(pos: [f32; 3]) -> glam::Vec3 {
+    glam::Vec3::from(pos)
 }
 
-fn create_vertices() -> (Vec<rend3::datatypes::ModelVertex>, Vec<u32>) {
-    let vertex_data = [
+fn create_mesh() -> rend3::datatypes::Mesh {
+    let vertex_positions = [
         // top (0.0, 0.0, 1.0)
         vertex([-1.0, -1.0, 1.0]),
         vertex([1.0, -1.0, 1.0]),
@@ -53,7 +45,21 @@ fn create_vertices() -> (Vec<rend3::datatypes::ModelVertex>, Vec<u32>) {
         22, 21, 20, 20, 23, 22, // back
     ];
 
-    (vertex_data.to_vec(), index_data.to_vec())
+    let count = vertex_positions.len();
+
+    let mut mesh = rend3::datatypes::Mesh {
+        vertex_positions: vertex_positions.to_vec(),
+        vertex_normals: vec![glam::Vec3::zero(); count],
+        vertex_uvs: vec![glam::Vec2::zero(); count],
+        vertex_colors: vec![[0; 4]; count],
+        vertex_material_indices: vec![0; count],
+        indices: index_data.to_vec(),
+    };
+
+    // Auto-calculate normals for us
+    mesh.calculate_normals();
+
+    mesh
 }
 
 fn main() {
@@ -84,9 +90,7 @@ fn main() {
     });
 
     // Create mesh and calculate smooth normals based on vertices
-    let (vertices, indices) = create_vertices();
-    let mut mesh = rend3::datatypes::Mesh { vertices, indices };
-    mesh.calculate_normals();
+    let mesh = create_mesh();
 
     // Add mesh to renderer's world
     let mesh_handle = renderer.add_mesh(mesh);

--- a/examples/gltf/src/main.rs
+++ b/examples/gltf/src/main.rs
@@ -8,8 +8,6 @@ fn load_gltf(
     let primitive = mesh_data.primitives().next().expect("no primitives in data.glb");
     let reader = primitive.reader(|b| Some(&datas.get(b.index())?.0[..b.length()]));
 
-    let indices = reader.read_indices().unwrap().into_u32().collect();
-
     let vertex_positions: Vec<_> = reader.read_positions().unwrap().map(glam::Vec3::from).collect();
     let vertex_normals: Vec<_> = reader.read_normals().unwrap().map(glam::Vec3::from).collect();
     let vertex_uvs: Vec<_> = reader
@@ -18,17 +16,13 @@ fn load_gltf(
         .into_f32()
         .map(glam::Vec2::from)
         .collect();
+    let indices = reader.read_indices().unwrap().into_u32().collect();
 
-    let count = vertex_positions.len();
-
-    let mesh = rend3::datatypes::Mesh {
-        vertex_positions,
-        vertex_normals,
-        vertex_uvs,
-        vertex_colors: vec![[0; 4]; count],
-        vertex_material_indices: vec![0; count],
-        indices,
-    };
+    let mesh = rend3::datatypes::MeshBuilder::new(vertex_positions.to_vec())
+        .with_vertex_normals(vertex_normals)
+        .with_vertex_uvs(vertex_uvs)
+        .with_indices(indices)
+        .build();
 
     // Add mesh to renderer's world
     let mesh_handle = renderer.add_mesh(mesh);

--- a/examples/imgui/src/main.rs
+++ b/examples/imgui/src/main.rs
@@ -47,21 +47,9 @@ fn create_mesh() -> rend3::datatypes::Mesh {
         22, 21, 20, 20, 23, 22, // back
     ];
 
-    let count = vertex_positions.len();
-
-    let mut mesh = rend3::datatypes::Mesh {
-        vertex_positions: vertex_positions.to_vec(),
-        vertex_normals: vec![glam::Vec3::zero(); count],
-        vertex_uvs: vec![glam::Vec2::zero(); count],
-        vertex_colors: vec![[0; 4]; count],
-        vertex_material_indices: vec![0; count],
-        indices: index_data.to_vec(),
-    };
-
-    // Auto-calculate normals for us
-    mesh.calculate_normals();
-
-    mesh
+    rend3::datatypes::MeshBuilder::new(vertex_positions.to_vec())
+        .with_indices(index_data.to_vec())
+        .build()
 }
 
 fn main() {

--- a/examples/imgui/src/main.rs
+++ b/examples/imgui/src/main.rs
@@ -1,19 +1,11 @@
 use std::{sync::Arc, time::Instant};
 
-fn vertex(pos: [f32; 3]) -> rend3::datatypes::ModelVertex {
-    rend3::datatypes::ModelVertex {
-        position: glam::Vec3::from(pos),
-        // Will be recalculated later.
-        normal: glam::Vec3::unit_y(),
-        // Only used with textures, we don't have one.
-        uv: glam::Vec2::zero(),
-        // We aren't using vertex colors.
-        color: [0, 0, 0, 0],
-    }
+fn vertex(pos: [f32; 3]) -> glam::Vec3 {
+    glam::Vec3::from(pos)
 }
 
-fn create_vertices() -> (Vec<rend3::datatypes::ModelVertex>, Vec<u32>) {
-    let vertex_data = [
+fn create_mesh() -> rend3::datatypes::Mesh {
+    let vertex_positions = [
         // top (0.0, 0.0, 1.0)
         vertex([-1.0, -1.0, 1.0]),
         vertex([1.0, -1.0, 1.0]),
@@ -55,7 +47,21 @@ fn create_vertices() -> (Vec<rend3::datatypes::ModelVertex>, Vec<u32>) {
         22, 21, 20, 20, 23, 22, // back
     ];
 
-    (vertex_data.to_vec(), index_data.to_vec())
+    let count = vertex_positions.len();
+
+    let mut mesh = rend3::datatypes::Mesh {
+        vertex_positions: vertex_positions.to_vec(),
+        vertex_normals: vec![glam::Vec3::zero(); count],
+        vertex_uvs: vec![glam::Vec2::zero(); count],
+        vertex_colors: vec![[0; 4]; count],
+        vertex_material_indices: vec![0; count],
+        indices: index_data.to_vec(),
+    };
+
+    // Auto-calculate normals for us
+    mesh.calculate_normals();
+
+    mesh
 }
 
 fn main() {
@@ -124,9 +130,7 @@ fn main() {
     });
 
     // Create mesh and calculate smooth normals based on vertices
-    let (vertices, indices) = create_vertices();
-    let mut mesh = rend3::datatypes::Mesh { vertices, indices };
-    mesh.calculate_normals();
+    let mesh = create_mesh();
 
     // Add mesh to renderer's world
     let mesh_handle = renderer.add_mesh(mesh);

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -180,46 +180,36 @@ where
                 Some(&binary[..b.length()])
             });
 
-            let mut vertices: Vec<_> = reader
+            let vertex_positions: Vec<_> = reader
                 .read_positions()
                 .ok_or_else(|| GltfLoadError::MissingPositions(mesh.index()))?
-                .map(|pos| rend3::datatypes::ModelVertex {
-                    position: Vec3::from(pos),
-                    normal: Default::default(),
-                    uv: Default::default(),
-                    color: [0; 4],
-                })
+                .map(Vec3::from)
                 .collect();
 
-            let has_normals = if let Some(normals) = reader.read_normals() {
-                vertices.iter_mut().zip(normals).for_each(|(vert, normal)| {
-                    vert.normal = Vec3::from(normal);
-                });
-                true
-            } else {
-                false
-            };
-            if let Some(coords) = reader.read_tex_coords(0) {
-                vertices.iter_mut().zip(coords.into_f32()).for_each(|(vert, coord)| {
-                    vert.uv = Vec2::from(coord);
-                });
-            }
-            if let Some(colors) = reader.read_colors(0) {
-                vertices
-                    .iter_mut()
-                    .zip(colors.into_rgba_u8())
-                    .for_each(|(vert, color)| {
-                        vert.color = color;
-                    });
-            }
+            let vertex_normals = reader.read_normals().map(|n| n.map(Vec3::from).collect::<Vec<_>>());
+            let vertex_uvs = reader
+                .read_tex_coords(0)
+                .map(|n| n.into_f32().map(Vec2::from).collect::<Vec<_>>());
+            let vertex_colors = reader.read_colors(0).map(|n| n.into_rgba_u8().collect::<Vec<_>>());
+
+            let count = vertex_positions.len();
 
             let indices: Vec<_> = if let Some(indices) = reader.read_indices() {
                 indices.into_u32().collect()
             } else {
-                (0..vertices.len() as u32).collect()
+                (0..count as u32).collect()
             };
 
-            let mut mesh = dt::Mesh { vertices, indices };
+            let has_normals = vertex_normals.is_some();
+
+            let mut mesh = dt::Mesh {
+                vertex_positions,
+                vertex_normals: vertex_normals.unwrap_or_else(|| vec![Vec3::zero(); count]),
+                vertex_uvs: vertex_uvs.unwrap_or_else(|| vec![Vec2::zero(); count]),
+                vertex_colors: vertex_colors.unwrap_or_else(|| vec![[0; 4]; count]),
+                vertex_material_indices: vec![0; count],
+                indices,
+            };
             if !has_normals {
                 mesh.calculate_normals();
             }

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -14,7 +14,7 @@ categories = []
 arrayvec = "0.5"
 bitflags = "1"
 bytemuck = "1"
-glam = "0.11"
+glam = { version = "0.11", features = ["bytemuck"] }
 include_dir = "0.6"
 indexmap = "1"
 itertools = "0.10"

--- a/rend3/src/renderer/frustum.rs
+++ b/rend3/src/renderer/frustum.rs
@@ -1,4 +1,3 @@
-use crate::datatypes::ModelVertex;
 use glam::{Mat4, Vec3, Vec3A, Vec4Swizzles};
 
 #[derive(Debug, Clone, Copy)]
@@ -8,7 +7,7 @@ pub struct BoundingSphere {
     pub radius: f32,
 }
 impl BoundingSphere {
-    pub fn from_mesh(mesh: &[ModelVertex]) -> Self {
+    pub fn from_mesh(mesh: &[Vec3]) -> Self {
         let center = find_mesh_center(mesh);
         let radius = find_mesh_bounding_sphere_radius(center, mesh);
 
@@ -40,18 +39,18 @@ impl BoundingSphere {
     }
 }
 
-fn find_mesh_center(mesh: &[ModelVertex]) -> Vec3A {
+fn find_mesh_center(mesh: &[Vec3]) -> Vec3A {
     let first = if let Some(first) = mesh.first() {
         *first
     } else {
         return Vec3A::zero();
     };
     // Bounding box time baby!
-    let mut max = Vec3A::from(first.position);
-    let mut min = Vec3A::from(first.position);
+    let mut max = Vec3A::from(first);
+    let mut min = max;
 
-    for vert in mesh.iter().skip(1) {
-        let pos = Vec3A::from(vert.position);
+    for pos in mesh.iter().skip(1) {
+        let pos = Vec3A::from(*pos);
         max = max.max(pos);
         min = min.min(pos);
     }
@@ -59,9 +58,9 @@ fn find_mesh_center(mesh: &[ModelVertex]) -> Vec3A {
     (max + min) / 2.0
 }
 
-fn find_mesh_bounding_sphere_radius(mesh_center: Vec3A, mesh: &[ModelVertex]) -> f32 {
-    mesh.iter().fold(0.0, |distance, vert| {
-        distance.max((Vec3A::from(vert.position) - mesh_center).length())
+fn find_mesh_bounding_sphere_radius(mesh_center: Vec3A, mesh: &[Vec3]) -> f32 {
+    mesh.iter().fold(0.0, |distance, pos| {
+        distance.max((Vec3A::from(*pos) - mesh_center).length())
     })
 }
 

--- a/rend3/src/renderer/list/forward.rs
+++ b/rend3/src/renderer/list/forward.rs
@@ -171,7 +171,7 @@ where
 
     let mesh_manager_guard = renderer.mesh_manager.read();
     let material_manager_guard = renderer.material_manager.read();
-    let (vertex, index) = mesh_manager_guard.buffers();
+    let buffers = mesh_manager_guard.buffers();
 
     let mut encoder = renderer.device.create_command_encoder(&CommandEncoderDescriptor {
         label: Some("single renderpass render encoder"),
@@ -194,8 +194,12 @@ where
             }
             RenderOpInputType::Models3D => match culling_data.inner {
                 ModeData::CPU(ref c) => {
-                    rpass.set_vertex_buffer(0, vertex.slice(..));
-                    rpass.set_index_buffer(index.slice(..));
+                    rpass.set_vertex_buffer(0, buffers.vertex_position.slice(..));
+                    rpass.set_vertex_buffer(1, buffers.vertex_normal.slice(..));
+                    rpass.set_vertex_buffer(2, buffers.vertex_uv.slice(..));
+                    rpass.set_vertex_buffer(3, buffers.vertex_color.slice(..));
+                    rpass.set_vertex_buffer(4, buffers.vertex_mat_index.slice(..));
+                    rpass.set_index_buffer(buffers.index.slice(..));
                     let mut last_material = None;
                     for (draw_call_idx, object) in c.iter().enumerate() {
                         for (idx, binding) in op.per_object_bindings.iter().enumerate() {
@@ -220,10 +224,14 @@ where
                     }
                 }
                 ModeData::GPU(ref g) => {
-                    rpass.set_vertex_buffer(0, vertex.slice(..));
-                    rpass.set_index_buffer(index.slice(..));
+                    rpass.set_vertex_buffer(0, buffers.vertex_position.slice(..));
+                    rpass.set_vertex_buffer(1, buffers.vertex_normal.slice(..));
+                    rpass.set_vertex_buffer(2, buffers.vertex_uv.slice(..));
+                    rpass.set_vertex_buffer(3, buffers.vertex_color.slice(..));
+                    rpass.set_vertex_buffer(4, buffers.vertex_mat_index.slice(..));
+                    rpass.set_index_buffer(buffers.index.slice(..));
 
-                    rpass.set_vertex_buffer(1, g.indirect_buffer.slice(..));
+                    rpass.set_vertex_buffer(5, g.indirect_buffer.slice(..));
                     rpass.multi_draw_indexed_indirect_count(
                         &g.indirect_buffer,
                         0,

--- a/rend3/src/renderer/material.rs
+++ b/rend3/src/renderer/material.rs
@@ -48,7 +48,7 @@ impl CPUShaderMaterial {
             anisotropy: material.anisotropy.to_value(0.0),
             ambient_occlusion: material.ao_factor.unwrap_or(1.0),
             alpha_cutout: material.alpha_cutout.unwrap_or(0.0),
-            texture_enable: dbg!(material.albedo.is_texture() as u32)
+            texture_enable: material.albedo.is_texture() as u32
                 | (material.normal.to_texture(|_| ()).is_some() as u32) << 1
                 | (material.aomr_textures.to_roughness_texture(|_| ()).is_some() as u32) << 2
                 | (material.aomr_textures.to_metallic_texture(|_| ()).is_some() as u32) << 3

--- a/rend3/src/renderer/pipeline.rs
+++ b/rend3/src/renderer/pipeline.rs
@@ -2,6 +2,9 @@ use crate::{
     datatypes::{DepthCompare, Pipeline, PipelineBindingType, PipelineHandle, PipelineInputType},
     list::RenderPassRunRate,
     registry::ResourceRegistry,
+    renderer::mesh::{
+        VERTEX_COLOR_SIZE, VERTEX_MATERIAL_INDEX_SIZE, VERTEX_NORMAL_SIZE, VERTEX_POSITION_SIZE, VERTEX_UV_SIZE,
+    },
     Renderer, RendererMode,
 };
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -61,192 +64,217 @@ impl PipelineManager {
     {
         let this = Arc::clone(&self);
         let renderer_clone = Arc::clone(&renderer);
-        renderer_clone.yard.spawn(renderer.yard_priorites.compute_pool, renderer.yard_priorites.pipeline_build_priority, async move {
-            let custom_layouts: Vec<_> = pipeline_desc
-                .bindings
-                .iter()
-                .filter_map(|bind| match bind {
-                    PipelineBindingType::Custom2DTexture { count } => {
-                        Some(create_custom_texture_bgl(&renderer.device, TextureViewDimension::D2, *count as u32))
-                    }
-                    PipelineBindingType::CustomCubeTexture { count } => {
-                        Some(create_custom_texture_bgl(&renderer.device, TextureViewDimension::Cube, *count as u32))
-                    }
-                    _ => None,
-                })
-                .collect();
+        renderer_clone.yard.spawn(
+            renderer.yard_priorites.compute_pool,
+            renderer.yard_priorites.pipeline_build_priority,
+            async move {
+                let custom_layouts: Vec<_> = pipeline_desc
+                    .bindings
+                    .iter()
+                    .filter_map(|bind| match bind {
+                        PipelineBindingType::Custom2DTexture { count } => Some(create_custom_texture_bgl(
+                            &renderer.device,
+                            TextureViewDimension::D2,
+                            *count as u32,
+                        )),
+                        PipelineBindingType::CustomCubeTexture { count } => Some(create_custom_texture_bgl(
+                            &renderer.device,
+                            TextureViewDimension::Cube,
+                            *count as u32,
+                        )),
+                        _ => None,
+                    })
+                    .collect();
 
-            let mut custom_layout_iter = custom_layouts.iter();
-            let mut uses_2d = false;
-            let mut uses_cube = false;
+                let mut custom_layout_iter = custom_layouts.iter();
+                let mut uses_2d = false;
+                let mut uses_cube = false;
 
-            let global_data = renderer.global_resources.read();
-            let texture_2d = renderer.texture_manager_2d.read();
-            let texture_cube = renderer.texture_manager_cube.read();
+                let global_data = renderer.global_resources.read();
+                let texture_2d = renderer.texture_manager_2d.read();
+                let texture_cube = renderer.texture_manager_cube.read();
 
-            let layouts: Vec<_> = pipeline_desc
-                .bindings
-                .iter()
-                .map(|bind| match bind {
-                    PipelineBindingType::GeneralData => &global_data.general_bgl,
-                    PipelineBindingType::ObjectData => &global_data.object_data_bgl,
-                    PipelineBindingType::CPUMaterial | PipelineBindingType::GPUMaterial => &global_data.material_bgl,
-                    PipelineBindingType::CameraData => &global_data.camera_data_bgl,
-                    PipelineBindingType::GPU2DTextures => {
-                        uses_2d = true;
-                        texture_2d.gpu_bind_group_layout()
-                    }
-                    PipelineBindingType::GPUCubeTextures => {
-                        uses_cube = true;
-                        texture_cube.gpu_bind_group_layout()
-                    }
-                    PipelineBindingType::ShadowTexture => &global_data.shadow_texture_bgl,
-                    PipelineBindingType::SkyboxTexture => &global_data.skybox_bgl,
-                    PipelineBindingType::Custom2DTexture { .. } => custom_layout_iter.next().unwrap(),
-                    PipelineBindingType::CustomCubeTexture { .. } => custom_layout_iter.next().unwrap(),
-                })
-                .collect();
+                let layouts: Vec<_> = pipeline_desc
+                    .bindings
+                    .iter()
+                    .map(|bind| match bind {
+                        PipelineBindingType::GeneralData => &global_data.general_bgl,
+                        PipelineBindingType::ObjectData => &global_data.object_data_bgl,
+                        PipelineBindingType::CPUMaterial | PipelineBindingType::GPUMaterial => {
+                            &global_data.material_bgl
+                        }
+                        PipelineBindingType::CameraData => &global_data.camera_data_bgl,
+                        PipelineBindingType::GPU2DTextures => {
+                            uses_2d = true;
+                            texture_2d.gpu_bind_group_layout()
+                        }
+                        PipelineBindingType::GPUCubeTextures => {
+                            uses_cube = true;
+                            texture_cube.gpu_bind_group_layout()
+                        }
+                        PipelineBindingType::ShadowTexture => &global_data.shadow_texture_bgl,
+                        PipelineBindingType::SkyboxTexture => &global_data.skybox_bgl,
+                        PipelineBindingType::Custom2DTexture { .. } => custom_layout_iter.next().unwrap(),
+                        PipelineBindingType::CustomCubeTexture { .. } => custom_layout_iter.next().unwrap(),
+                    })
+                    .collect();
 
-            let cpu_push_constants = [PushConstantRange {
-                range: 0..4,
-                stages: ShaderStage::VERTEX | ShaderStage::FRAGMENT
-            }];
+                let cpu_push_constants = [PushConstantRange {
+                    range: 0..4,
+                    stages: ShaderStage::VERTEX | ShaderStage::FRAGMENT,
+                }];
 
-            let push_constant_ranges = match renderer.mode {
-                RendererMode::CPUPowered => {
-                    &cpu_push_constants[..]
-                }
-                RendererMode::GPUPowered => {
-                    &[]
-                }
-            };
+                let push_constant_ranges = match renderer.mode {
+                    RendererMode::CPUPowered => &cpu_push_constants[..],
+                    RendererMode::GPUPowered => &[],
+                };
 
-            let pipeline_layout = renderer.device.create_pipeline_layout(&PipelineLayoutDescriptor {
-                label: None,
-                bind_group_layouts: &layouts,
-                push_constant_ranges,
-            });
+                let pipeline_layout = renderer.device.create_pipeline_layout(&PipelineLayoutDescriptor {
+                    label: None,
+                    bind_group_layouts: &layouts,
+                    push_constant_ranges,
+                });
 
-            drop((global_data, texture_2d, texture_cube));
+                drop((global_data, texture_2d, texture_cube));
 
-            let color_states: Vec<_> = pipeline_desc
-                .outputs
-                .iter()
-                .map(|&attachment| ColorStateDescriptor {
-                    alpha_blend: BlendDescriptor::REPLACE,
-                    color_blend: BlendDescriptor::REPLACE,
-                    write_mask: match attachment.write {
-                        true => ColorWrite::ALL,
-                        false => ColorWrite::empty(),
+                let color_states: Vec<_> = pipeline_desc
+                    .outputs
+                    .iter()
+                    .map(|&attachment| ColorStateDescriptor {
+                        alpha_blend: BlendDescriptor::REPLACE,
+                        color_blend: BlendDescriptor::REPLACE,
+                        write_mask: match attachment.write {
+                            true => ColorWrite::ALL,
+                            false => ColorWrite::empty(),
+                        },
+                        format: attachment.format,
+                    })
+                    .collect();
+
+                let depth_state = pipeline_desc.depth.map(|state| DepthStencilStateDescriptor {
+                    format: state.format,
+                    depth_write_enabled: true,
+                    depth_compare: match (state.compare, pipeline_desc.run_rate) {
+                        // Shadow modes
+                        (DepthCompare::Closer, RenderPassRunRate::PerShadow) => CompareFunction::Less,
+                        (DepthCompare::CloserEqual, RenderPassRunRate::PerShadow) => CompareFunction::LessEqual,
+                        (DepthCompare::Equal, RenderPassRunRate::PerShadow) => CompareFunction::Equal,
+                        (DepthCompare::Further, RenderPassRunRate::PerShadow) => CompareFunction::Greater,
+                        (DepthCompare::FurtherEqual, RenderPassRunRate::PerShadow) => CompareFunction::GreaterEqual,
+
+                        // Forward modes
+                        (DepthCompare::Closer, RenderPassRunRate::Once) => CompareFunction::Greater,
+                        (DepthCompare::CloserEqual, RenderPassRunRate::Once) => CompareFunction::GreaterEqual,
+                        (DepthCompare::Equal, RenderPassRunRate::Once) => CompareFunction::Equal,
+                        (DepthCompare::Further, RenderPassRunRate::Once) => CompareFunction::Less,
+                        (DepthCompare::FurtherEqual, RenderPassRunRate::Once) => CompareFunction::LessEqual,
                     },
-                    format: attachment.format,
-                })
-                .collect();
+                    stencil: StencilStateDescriptor::default(),
+                });
 
-            let depth_state = pipeline_desc.depth.map(|state| DepthStencilStateDescriptor {
-                format: state.format,
-                depth_write_enabled: true,
-                depth_compare: match (state.compare, pipeline_desc.run_rate) {
-                    // Shadow modes
-                    (DepthCompare::Closer, RenderPassRunRate::PerShadow) => CompareFunction::Less,
-                    (DepthCompare::CloserEqual, RenderPassRunRate::PerShadow) => CompareFunction::LessEqual,
-                    (DepthCompare::Equal, RenderPassRunRate::PerShadow) => CompareFunction::Equal,
-                    (DepthCompare::Further, RenderPassRunRate::PerShadow) => CompareFunction::Greater,
-                    (DepthCompare::FurtherEqual, RenderPassRunRate::PerShadow) => CompareFunction::GreaterEqual,
-
-                    // Forward modes
-                    (DepthCompare::Closer, RenderPassRunRate::Once) => CompareFunction::Greater,
-                    (DepthCompare::CloserEqual, RenderPassRunRate::Once) => CompareFunction::GreaterEqual,
-                    (DepthCompare::Equal, RenderPassRunRate::Once) => CompareFunction::Equal,
-                    (DepthCompare::Further, RenderPassRunRate::Once) => CompareFunction::Less,
-                    (DepthCompare::FurtherEqual, RenderPassRunRate::Once) => CompareFunction::LessEqual,
-                },
-                stencil: StencilStateDescriptor::default(),
-            });
-
-            let vertex_states = [
-                wgpu::VertexBufferDescriptor {
-                    stride: std::mem::size_of::<crate::datatypes::ModelVertex>() as u64,
-                    step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float3, 1 => Float3, 2 => Float2, 3 => Uchar4Norm, 4 => Uint],
-                },
-                wgpu::VertexBufferDescriptor {
-                    stride: 20,
-                    step_mode: wgpu::InputStepMode::Instance,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
+                let vertex_states = [
+                    wgpu::VertexBufferDescriptor {
+                        stride: VERTEX_POSITION_SIZE as u64,
+                        step_mode: wgpu::InputStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![0 => Float3],
+                    },
+                    wgpu::VertexBufferDescriptor {
+                        stride: VERTEX_NORMAL_SIZE as u64,
+                        step_mode: wgpu::InputStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![1 => Float3],
+                    },
+                    wgpu::VertexBufferDescriptor {
+                        stride: VERTEX_UV_SIZE as u64,
+                        step_mode: wgpu::InputStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![2 => Float2],
+                    },
+                    wgpu::VertexBufferDescriptor {
+                        stride: VERTEX_COLOR_SIZE as u64,
+                        step_mode: wgpu::InputStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![3 => Uchar4Norm],
+                    },
+                    wgpu::VertexBufferDescriptor {
+                        stride: VERTEX_MATERIAL_INDEX_SIZE as u64,
+                        step_mode: wgpu::InputStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array![4 => Uint],
+                    },
+                    wgpu::VertexBufferDescriptor {
+                        stride: 20,
+                        step_mode: wgpu::InputStepMode::Instance,
+                        attributes: &[wgpu::VertexAttributeDescriptor {
                             format: wgpu::VertexFormat::Uint,
                             offset: 16,
-                            shader_location: 5
-                        }
-                    ],
-                }
-            ];
+                            shader_location: 5,
+                        }],
+                    },
+                ];
 
-            let fragment_stage_module = pipeline_desc.fragment.map(|handle| renderer.shader_manager.get(handle));
+                let fragment_stage_module = pipeline_desc.fragment.map(|handle| renderer.shader_manager.get(handle));
 
-            let pipeline = renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
-                label: None,
-                layout: Some(&pipeline_layout),
-                vertex_stage: ProgrammableStageDescriptor {
-                    entry_point: "main",
-                    module: &renderer.shader_manager.get(pipeline_desc.vertex),
-                },
-                fragment_stage: fragment_stage_module.as_ref().map(|module| ProgrammableStageDescriptor {
-                    entry_point: "main",
-                    module: &module,
-                }),
-                rasterization_state: Some(RasterizationStateDescriptor {
-                    front_face: FrontFace::Ccw,
-                    cull_mode: match (pipeline_desc.input, pipeline_desc.run_rate) {
-                        (PipelineInputType::FullscreenTriangle, _) => CullMode::None,
-                        (PipelineInputType::Models3d, RenderPassRunRate::Once) => CullMode::Back,
-                        (PipelineInputType::Models3d, RenderPassRunRate::PerShadow) => CullMode::Front,
+                let pipeline = renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
+                    label: None,
+                    layout: Some(&pipeline_layout),
+                    vertex_stage: ProgrammableStageDescriptor {
+                        entry_point: "main",
+                        module: &renderer.shader_manager.get(pipeline_desc.vertex),
                     },
-                    clamp_depth: match pipeline_desc.run_rate {
-                        // TODO
-                        RenderPassRunRate::PerShadow => false,
-                        RenderPassRunRate::Once => false,
-                    },
-                    depth_bias: match pipeline_desc.run_rate {
-                        RenderPassRunRate::PerShadow => 2,
-                        RenderPassRunRate::Once => 0,
-                    },
-                    depth_bias_slope_scale: match pipeline_desc.run_rate {
-                        RenderPassRunRate::PerShadow => 2.0,
-                        RenderPassRunRate::Once => 0.0,
-                    },
-                    depth_bias_clamp: 0.0,
-                }),
-                primitive_topology: PrimitiveTopology::TriangleList,
-                color_states: &color_states,
-                depth_stencil_state: depth_state,
-                vertex_state: VertexStateDescriptor {
-                    index_format: IndexFormat::Uint32,
-                    vertex_buffers: match pipeline_desc.input {
-                        PipelineInputType::FullscreenTriangle => &[],
-                        PipelineInputType::Models3d => match renderer.mode {
-                            RendererMode::CPUPowered => {
-                                &vertex_states[0..1]
-                            }
-                            RendererMode::GPUPowered => {
-                                &vertex_states
-                            }
+                    fragment_stage: fragment_stage_module
+                        .as_ref()
+                        .map(|module| ProgrammableStageDescriptor {
+                            entry_point: "main",
+                            module: &module,
+                        }),
+                    rasterization_state: Some(RasterizationStateDescriptor {
+                        front_face: FrontFace::Ccw,
+                        cull_mode: match (pipeline_desc.input, pipeline_desc.run_rate) {
+                            (PipelineInputType::FullscreenTriangle, _) => CullMode::None,
+                            (PipelineInputType::Models3d, RenderPassRunRate::Once) => CullMode::Back,
+                            (PipelineInputType::Models3d, RenderPassRunRate::PerShadow) => CullMode::Front,
+                        },
+                        clamp_depth: match pipeline_desc.run_rate {
+                            // TODO
+                            RenderPassRunRate::PerShadow => false,
+                            RenderPassRunRate::Once => false,
+                        },
+                        depth_bias: match pipeline_desc.run_rate {
+                            RenderPassRunRate::PerShadow => 2,
+                            RenderPassRunRate::Once => 0,
+                        },
+                        depth_bias_slope_scale: match pipeline_desc.run_rate {
+                            RenderPassRunRate::PerShadow => 2.0,
+                            RenderPassRunRate::Once => 0.0,
+                        },
+                        depth_bias_clamp: 0.0,
+                    }),
+                    primitive_topology: PrimitiveTopology::TriangleList,
+                    color_states: &color_states,
+                    depth_stencil_state: depth_state,
+                    vertex_state: VertexStateDescriptor {
+                        index_format: IndexFormat::Uint32,
+                        vertex_buffers: match pipeline_desc.input {
+                            PipelineInputType::FullscreenTriangle => &[],
+                            PipelineInputType::Models3d => match renderer.mode {
+                                RendererMode::CPUPowered => &vertex_states[0..5],
+                                RendererMode::GPUPowered => &vertex_states,
+                            },
                         },
                     },
-                },
-                sample_count: pipeline_desc.samples as u32,
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
-            });
+                    sample_count: pipeline_desc.samples as u32,
+                    sample_mask: !0,
+                    alpha_to_coverage_enabled: false,
+                });
 
-            this.registry.write().insert(handle.0, CompiledPipeline {
-                desc: pipeline_desc,
-                inner: Arc::new(pipeline),
-                uses_2d,
-                uses_cube,
-            });
-        })
+                this.registry.write().insert(
+                    handle.0,
+                    CompiledPipeline {
+                        desc: pipeline_desc,
+                        inner: Arc::new(pipeline),
+                        uses_2d,
+                        uses_cube,
+                    },
+                );
+            },
+        )
     }
 
     pub fn recompile_pipelines<TD>(


### PR DESCRIPTION
This serves two purposes, moving to SOA vertex buffers, but also adding a MeshBuilder which enables easier creation of meshes, which are rather clunky at the moment.

Closes #38
First step towards #59 
