### PR TITLE
Fix crash when object count is zero

### DIFF
--- a/rend3/src/renderer/object.rs
+++ b/rend3/src/renderer/object.rs
@@ -95,6 +95,10 @@ impl ObjectManager {
 
         let object_count = self.registry.count();
 
+        if object_count == 0 {
+            return object_count;
+        }
+
         if let ModeData::GPU(ref mut obj_buffer) = self.object_info_buffer {
             let registry = &self.registry;
 


### PR DESCRIPTION
Zero-sized buffers don't really work, so just don't write to the object buffer when theres nothing to show