### PR TITLE
Make 'render' borrow 'OutputFrame' instead of taking ownership of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to cargo's version of [Semantic Versioning](https://sem
 
 ## Unreleased
 
+- rend3 borrow `OutputFrame` instead of taking ownership @MindSwipe
+
 ## v0.1.1
 
 Released 2021-09-13

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -182,7 +182,7 @@ fn main() {
             // Get a frame
             let frame = rend3::util::output::OutputFrame::from_surface(&surface).unwrap();
             // Dispatch a render!
-            let _stats = renderer.render(&mut routine, frame);
+            let _stats = renderer.render(&mut routine, &frame);
         }
         // Other events we don't care about
         _ => {}

--- a/examples/gltf/src/main.rs
+++ b/examples/gltf/src/main.rs
@@ -165,7 +165,7 @@ fn main() {
             // Get a frame
             let frame = rend3::util::output::OutputFrame::from_surface(&surface).unwrap();
             // Dispatch a render!
-            let _stats = renderer.render(&mut routine, frame);
+            let _stats = renderer.render(&mut routine, &frame);
         }
         // Other events we don't care about
         _ => {}

--- a/examples/scene-viewer/src/main.rs
+++ b/examples/scene-viewer/src/main.rs
@@ -341,7 +341,7 @@ fn main() {
             // Get a frame
             let frame = rend3::util::output::OutputFrame::from_surface(&surface).unwrap();
             // Dispatch a render!
-            previous_profiling_stats = renderer.render(&mut routine, frame);
+            previous_profiling_stats = renderer.render(&mut routine, &frame);
             // mark the end of the frame for tracy/other profilers
             profiling::finish_frame!();
         }

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -212,7 +212,7 @@ impl Renderer {
     pub fn render(
         self: &Arc<Self>,
         routine: &mut dyn RenderRoutine,
-        output: OutputFrame,
+        output: &OutputFrame,
     ) -> Option<RendererStatistics> {
         render::render_loop(Arc::clone(self), routine, output)
     }

--- a/rend3/src/renderer/render.rs
+++ b/rend3/src/renderer/render.rs
@@ -257,7 +257,7 @@ pub fn render_loop(
     let mut encoders = Vec::with_capacity(16);
     encoders.push(encoder.finish());
 
-    routine.render(Arc::clone(&renderer), &mut encoders, &frame);
+    routine.render(Arc::clone(&renderer), &mut encoders, frame);
 
     let mut encoder = renderer.device.create_command_encoder(&CommandEncoderDescriptor {
         label: Some("resolve encoder"),

--- a/rend3/src/renderer/render.rs
+++ b/rend3/src/renderer/render.rs
@@ -15,7 +15,7 @@ use wgpu::{
 pub fn render_loop(
     renderer: Arc<Renderer>,
     routine: &mut dyn RenderRoutine,
-    frame: OutputFrame,
+    frame: &OutputFrame,
 ) -> Option<RendererStatistics> {
     profiling::scope!("render_loop");
 


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Problems PR Solves
Makes the render function of `Renderer` borrow the `OutputFrame` instead of taking owenrship

## Related Issues

Closes #193 