### PR TITLE
Rename `CameraProjection::Projection` to `CameraProjection::Perspective`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Unreleased
 
+- rend3: Rename `CameraProjection::Projection` to `CameraProjection::Perspective`.
+
 ## v0.2.0
 
 Released 2021-10-09

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -126,7 +126,7 @@ fn main() {
 
     // Set camera's location
     renderer.set_camera_data(rend3::types::Camera {
-        projection: rend3::types::CameraProjection::Projection { vfov: 60.0, near: 0.1 },
+        projection: rend3::types::CameraProjection::Perspective { vfov: 60.0, near: 0.1 },
         view,
     });
 

--- a/examples/gltf/src/main.rs
+++ b/examples/gltf/src/main.rs
@@ -109,7 +109,7 @@ fn main() {
 
     // Set camera's location
     renderer.set_camera_data(rend3::types::Camera {
-        projection: rend3::types::CameraProjection::Projection { vfov: 60.0, near: 0.1 },
+        projection: rend3::types::CameraProjection::Perspective { vfov: 60.0, near: 0.1 },
         view,
     });
 

--- a/examples/scene-viewer/src/main.rs
+++ b/examples/scene-viewer/src/main.rs
@@ -371,7 +371,7 @@ fn main() {
             let view = view * Mat4::from_translation((-camera_location).into());
 
             renderer.set_camera_data(Camera {
-                projection: CameraProjection::Projection {
+                projection: CameraProjection::Perspective {
                     vfov: 60.0,
                     near: 0.1,
                 },

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -659,7 +659,7 @@ pub enum CameraProjection {
         /// Size assumes the location is at the center of the camera area.
         size: Vec3A,
     },
-    Projection {
+    Perspective {
         /// Vertical field of view in degrees.
         vfov: f32,
         /// Near plane distance. All projection uses a infinite far plane.
@@ -669,7 +669,7 @@ pub enum CameraProjection {
 
 impl Default for CameraProjection {
     fn default() -> Self {
-        Self::Projection { vfov: 60.0, near: 0.1 }
+        Self::Perspective { vfov: 60.0, near: 0.1 }
     }
 }
 

--- a/rend3/src/resources/camera.rs
+++ b/rend3/src/resources/camera.rs
@@ -78,7 +78,7 @@ fn compute_projection_matrix(data: Camera, aspect_ratio: f32) -> Mat4 {
             let half = size * 0.5;
             Mat4::orthographic_lh(-half.x, half.x, -half.y, half.y, -half.z, half.z)
         }
-        CameraProjection::Projection { vfov, near, .. } => {
+        CameraProjection::Perspective { vfov, near, .. } => {
             Mat4::perspective_infinite_reverse_lh(vfov.to_radians(), aspect_ratio, near)
         }
     }


### PR DESCRIPTION
Rename `CameraProjection::Projection` to `CameraProjection::Perspective`, the correct nomeclature.

## Checklist

- Cargo clippy reported no issues and the examples ran normally (tested on Linux).
- Updated changelog.
- No credit needed.

Fix the issue: https://github.com/BVE-Reborn/rend3/issues/231