### PR TITLE
Get vertex/index counts from RangeAllocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,16 @@ Per Keep a Changelog there are 6 main categories of changes:
 ### Changes
 - rend3: Instead of passing a render routine to the render function, you now add them to a rendergraph, then pass that rendergraph into the renderer.
   - rend3-routine:
-    - Split the PbrRoutine into two parts `add_prepass_to_graph` and `add_forward_to_graph`. 
+    - Split the PbrRoutine into two parts `add_prepass_to_graph` and `add_forward_to_graph`.
     - Split out the skybox renderer into `SkyboxRoutine`.
     - Split out tonemapping into the `TonemappingRoutine`.
 - rend3: All meshes now require validation.
   - `MeshBuilder::build()` now returns a `Result<Mesh, MeshValidationError>`. This validation can be unsafely omitted.
   - The implementation functions `Mesh::calculate_normals_for_buffers` and `Mesh::calculate_tangents_for_buffers` are now unsafe.
 - rend3: Rename `CameraProjection::Projection` to `CameraProjection::Perspective`.
+
+### Fixes
+- rend3: Get vertex/index counts from RangeAllocator. @jamen
 
 ## v0.2.0
 
@@ -126,7 +129,7 @@ Released 2021-09-11
 - rend3: `Texture::mip_levels` was split into `mip_count` and `mip_source` allowing you to easily auto-generate mipmaps.
 - rend3: Changed limits such that intel gets CPU mode until [wgpu#1111](https://github.com/gfx-rs/wgpu/issues/1111) gets resolved.
 - rend3-pbr: creation and resizing's `resolution` argument replaced with options containing resolution and sample count.
-  
+
 ### Updated
 - Dependencies:
   - `glam` 0.17 -> 0.18

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -67,10 +67,7 @@ impl MeshBuffers {
 pub struct MeshManager {
     buffers: MeshBuffers,
 
-    vertex_count: usize,
     vertex_alloc: RangeAllocator<usize>,
-
-    index_count: usize,
     index_alloc: RangeAllocator<usize>,
 
     registry: ResourceRegistry<InternalMesh, Mesh>,
@@ -82,19 +79,14 @@ impl MeshManager {
 
         let buffers = create_buffers(device, STARTING_VERTICES, STARTING_INDICES);
 
-        let vertex_count = STARTING_VERTICES;
-        let index_count = STARTING_INDICES;
-
-        let vertex_alloc = RangeAllocator::new(0..vertex_count);
-        let index_alloc = RangeAllocator::new(0..index_count);
+        let vertex_alloc = RangeAllocator::new(0..STARTING_VERTICES);
+        let index_alloc = RangeAllocator::new(0..STARTING_INDICES);
 
         let registry = ResourceRegistry::new();
 
         Self {
             buffers,
-            vertex_count,
             vertex_alloc,
-            index_count,
             index_alloc,
             registry,
         }
@@ -216,17 +208,17 @@ impl MeshManager {
     ) {
         profiling::scope!("reallocate mesh buffers");
 
-        let new_vert_count = (self.vertex_count + needed_verts as usize).next_power_of_two();
-        let new_index_count = (self.index_count + needed_indices as usize).next_power_of_two();
+        let new_vert_count = (self.vertex_count() + needed_verts as usize).next_power_of_two();
+        let new_index_count = (self.index_count() + needed_indices as usize).next_power_of_two();
 
         log::debug!(
             "Recreating vertex buffer from {} to {}",
-            self.vertex_count,
+            self.vertex_count(),
             new_vert_count
         );
         log::debug!(
             "Recreating index buffer from {} to {}",
-            self.index_count,
+            self.index_count(),
             new_index_count
         );
 
@@ -313,10 +305,16 @@ impl MeshManager {
         }
 
         self.buffers = new_buffers;
-        self.vertex_count = new_vert_count;
-        self.index_count = new_index_count;
         self.vertex_alloc = new_vert_alloc;
         self.index_alloc = new_index_alloc;
+    }
+
+    fn vertex_count(&self) -> usize {
+        self.vertex_alloc.initial_range().end
+    }
+
+    fn index_count(&self) -> usize {
+        self.index_alloc.initial_range().end
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] ~~changes added to changelog~~ because its an internal change it doesn't need a note i think, but otherwise i can add it

## Problems PR Solves

the vertex/index count can be accessed from RangeAllocator so it doesn't need to be stored twice
