### PR TITLE
Add `CameraProjection::Raw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Per Keep a Changelog there are 6 main categories of changes:
   - `MeshBuilder::build()` now returns a `Result<Mesh, MeshValidationError>`. This validation can be unsafely omitted.
   - The implementation functions `Mesh::calculate_normals_for_buffers` and `Mesh::calculate_tangents_for_buffers` are now unsafe.
 - rend3: Rename `CameraProjection::Projection` to `CameraProjection::Perspective`.
+- rend3: Add `CameraProjection::Raw`.
 - rend3-routine: All transparency now has backface culling enabled. Use `Mesh::double_side` or `MeshBuilder::with_double_side` to re-enable double sided transparency.
 
 ### Fixes

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -866,6 +866,7 @@ pub enum CameraProjection {
         /// Near plane distance. All projection uses a infinite far plane.
         near: f32,
     },
+    Raw(Mat4),
 }
 
 impl Default for CameraProjection {

--- a/rend3/src/managers/camera.rs
+++ b/rend3/src/managers/camera.rs
@@ -81,6 +81,7 @@ fn compute_projection_matrix(data: Camera, aspect_ratio: f32) -> Mat4 {
         CameraProjection::Perspective { vfov, near, .. } => {
             Mat4::perspective_infinite_reverse_lh(vfov.to_radians(), aspect_ratio, near)
         }
+        CameraProjection::Raw(proj) => proj,
     }
 }
 


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [ ] ~~Add credit to yourself for each change: `Added new functionality @githubname`.~~ no need, it's a really minor change

## Problems PR Solves

Allow to set a custom matrix for the camera projection. My use-case is using 4-value FoV (left, right, top, bottom) for VR.