### PR TITLE
Allow requesting device features explicitly in create_iad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3: Rename `CameraProjection::Projection` to `CameraProjection::Perspective`.
 - rend3: Add `CameraProjection::Raw`.
 - rend3-routine: All transparency now has backface culling enabled. Use `Mesh::double_side` or `MeshBuilder::with_double_side` to re-enable double sided transparency.
+- rend3: Allow requesting device features explicitly in `rend3::create_iad`. @setzer22
 
 ### Fixes
 - rend3: Get vertex/index counts from RangeAllocator. @jamen

--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
     let window_size = window.inner_size();
 
     // Create the Instance, Adapter, and Device. We can specify preferred backend, device name, or rendering mode. In this case we let rend3 choose for us.
-    let iad = pollster::block_on(rend3::create_iad(None, None, None, &[])).unwrap();
+    let iad = pollster::block_on(rend3::create_iad(None, None, None, None)).unwrap();
 
     // The one line of unsafe needed. We just need to guarentee that the window outlives the use of the surface.
     let surface = Arc::new(unsafe { iad.instance.create_surface(&window) });

--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
     let window_size = window.inner_size();
 
     // Create the Instance, Adapter, and Device. We can specify preferred backend, device name, or rendering mode. In this case we let rend3 choose for us.
-    let iad = pollster::block_on(rend3::create_iad(None, None, None)).unwrap();
+    let iad = pollster::block_on(rend3::create_iad(None, None, None, &[])).unwrap();
 
     // The one line of unsafe needed. We just need to guarentee that the window outlives the use of the surface.
     let surface = Arc::new(unsafe { iad.instance.create_surface(&window) });

--- a/examples/scene-viewer/src/main.rs
+++ b/examples/scene-viewer/src/main.rs
@@ -201,7 +201,7 @@ impl rend3_framework::App for SceneViewer {
                 self.desired_backend,
                 self.desired_device_name.clone(),
                 self.desired_mode,
-                &[],
+                None,
             )
             .await?)
         })

--- a/examples/scene-viewer/src/main.rs
+++ b/examples/scene-viewer/src/main.rs
@@ -201,6 +201,7 @@ impl rend3_framework::App for SceneViewer {
                 self.desired_backend,
                 self.desired_device_name.clone(),
                 self.desired_mode,
+                &[],
             )
             .await?)
         })

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -79,7 +79,7 @@ pub trait App<T: 'static = ()> {
     }
 
     fn create_iad<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = anyhow::Result<InstanceAdapterDevice>> + 'a>> {
-        Box::pin(async move { Ok(rend3::create_iad(None, None, None).await?) })
+        Box::pin(async move { Ok(rend3::create_iad(None, None, None, &[]).await?) })
     }
 
     /// Determines the sample count used at all times, this may change dynamically,

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -79,7 +79,7 @@ pub trait App<T: 'static = ()> {
     }
 
     fn create_iad<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = anyhow::Result<InstanceAdapterDevice>> + 'a>> {
-        Box::pin(async move { Ok(rend3::create_iad(None, None, None, &[]).await?) })
+        Box::pin(async move { Ok(rend3::create_iad(None, None, None, None).await?) })
     }
 
     /// Determines the sample count used at all times, this may change dynamically,

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -353,7 +353,7 @@ pub async fn create_iad(
     desired_backend: Option<Backend>,
     desired_device: Option<String>,
     desired_mode: Option<RendererMode>,
-    additional_features: &[Features],
+    additional_features: Option<Features>,
 ) -> Result<InstanceAdapterDevice, RendererInitializationError> {
     profiling::scope!("create_iad");
     #[cfg(not(target_arch = "wasm32"))]
@@ -455,9 +455,7 @@ pub async fn create_iad(
                 .request_device(
                     &DeviceDescriptor {
                         label: None,
-                        features: adapter
-                            .features
-                            .union(Features::from_iter(additional_features.iter().cloned())),
+                        features: adapter.features.union(additional_features.unwrap_or(Features::empty())),
                         limits: adapter.limits,
                     },
                     None,

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -455,7 +455,9 @@ pub async fn create_iad(
                 .request_device(
                     &DeviceDescriptor {
                         label: None,
-                        features: adapter.features.union(additional_features.unwrap_or_else(Features::empty)),
+                        features: adapter
+                            .features
+                            .union(additional_features.unwrap_or_else(Features::empty)),
                         limits: adapter.limits,
                     },
                     None,

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -345,9 +345,9 @@ pub struct InstanceAdapterDevice {
     pub info: ExtendedAdapterInfo,
 }
 
-/// Creates an Instance/Adapter/Device/Queue using the given choices. Tries to /// get the best combination. 
-/// 
-/// **NOTE:** Some adapters will not advertise all of its supported features. The `additional_features` 
+/// Creates an Instance/Adapter/Device/Queue using the given choices. Tries to get the best combination.
+///
+/// **NOTE:** Some adapters will not advertise all of its supported features. The `additional_features`
 /// parameter can be used to explicitly request additional features during device creation.
 pub async fn create_iad(
     desired_backend: Option<Backend>,

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -455,7 +455,7 @@ pub async fn create_iad(
                 .request_device(
                     &DeviceDescriptor {
                         label: None,
-                        features: adapter.features.union(additional_features.unwrap_or(Features::empty())),
+                        features: adapter.features.union(additional_features.unwrap_or_else(Features::empty)),
                         limits: adapter.limits,
                     },
                     None,

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -345,11 +345,15 @@ pub struct InstanceAdapterDevice {
     pub info: ExtendedAdapterInfo,
 }
 
-/// Creates an Instance/Adapter/Device/Queue using the given choices. Tries to get the best combination.
+/// Creates an Instance/Adapter/Device/Queue using the given choices. Tries to /// get the best combination. 
+/// 
+/// **NOTE:** Some adapters will not advertise all of its supported features. The `additional_features` 
+/// parameter can be used to explicitly request additional features during device creation.
 pub async fn create_iad(
     desired_backend: Option<Backend>,
     desired_device: Option<String>,
     desired_mode: Option<RendererMode>,
+    additional_features: &[Features],
 ) -> Result<InstanceAdapterDevice, RendererInitializationError> {
     profiling::scope!("create_iad");
     #[cfg(not(target_arch = "wasm32"))]
@@ -451,7 +455,9 @@ pub async fn create_iad(
                 .request_device(
                     &DeviceDescriptor {
                         label: None,
-                        features: adapter.features,
+                        features: adapter
+                            .features
+                            .union(Features::from_iter(additional_features.iter().cloned())),
                         limits: adapter.limits,
                     },
                     None,


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Problems PR Solves
This PR allows explicitly requesting device features when those are not reported by the adapter.

## Related Issues
 More details can be found in #292