### PR TITLE
Fix `RenderPassTargets::compatible` to prevent some false positives 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ### Fixes
 - rend3: Get vertex/index counts from RangeAllocator. @jamen
+- rend3: Fix compatibility comparison for RenderPassTargets. @setzer22
 
 ## v0.2.0
 

--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,9 @@ skip = [
     { name = "wasi", version = "0.10.2" },
     # egui
     { name = "owned_ttf_parser", version = "0.6.0" },
-    { name = "ttf-parser", version = "0.6.2" }
+    { name = "ttf-parser", version = "0.6.2" },
+    # serde_json
+    { name = "itoa", version = "0.4.8"},
 ]
 
 [advisories]

--- a/deny.toml
+++ b/deny.toml
@@ -42,7 +42,7 @@ skip = [
     # egui
     { name = "owned_ttf_parser", version = "0.6.0" },
     { name = "ttf-parser", version = "0.6.2" },
-    # serde_json
+    # web stack
     { name = "itoa", version = "0.4.8"},
 ]
 

--- a/rend3/src/graph/mod.rs
+++ b/rend3/src/graph/mod.rs
@@ -869,17 +869,18 @@ impl RenderPassTargets {
     fn compatible(this: Option<&Self>, other: Option<&Self>) -> bool {
         match (this, other) {
             (Some(this), Some(other)) => {
-                let targets_compatible = this
-                    .targets
-                    .iter()
-                    .zip(other.targets.iter())
-                    .all(|(me, you)| me.color == you.color && me.resolve == you.resolve);
+                let targets_compatible = this.targets.len() == other.targets.len()
+                    && this
+                        .targets
+                        .iter()
+                        .zip(other.targets.iter())
+                        .all(|(me, you)| me.color == you.color && me.resolve == you.resolve);
 
-                let depth_compatible = this
-                    .depth_stencil
-                    .as_ref()
-                    .zip(other.depth_stencil.as_ref())
-                    .map_or(true, |(me, you)| me.target == you.target);
+                let depth_compatible = match (&this.depth_stencil, &other.depth_stencil) {
+                    (Some(this_depth), Some(other_depth)) => this_depth == other_depth,
+                    (None, None) => true,
+                    _ => false,
+                };
 
                 targets_compatible && depth_compatible
             }


### PR DESCRIPTION

## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Problems PR Solves

As discussed on Matrix, there was a bug in `RenderPassTarget::compatible` where two incompatible `RenderPassTargets` would be incorrectly flagged as compatible.

I found two different logic problems: 

- For the `targets_compatible` check to pass, the lists should be of equal length, otherwise `zip` will stop at the shortest one and report them as equal.
- For the `depth_compatible` test, the `map_or(true, ...)` was not correct when only one of the two `depth_stencil` targets was `None`. I have changed the logic separating the three cases in a match statement and I think now it's a bit more clear.

## Related Issues

None, that I know of.
