### PR TITLE
Change `loaded` in `load_gltf_nodes` to be a shared ref.

### DIFF
--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -295,7 +295,7 @@ pub fn add_mesh_by_index<E: std::error::Error + 'static>(
 
 pub fn load_gltf_nodes<'a, E: std::error::Error + 'static>(
     renderer: &Renderer,
-    loaded: &mut LoadedGltfScene,
+    loaded: &LoadedGltfScene,
     nodes: impl Iterator<Item = gltf::Node<'a>>,
     parent_transform: Mat4,
 ) -> Result<Vec<Labeled<Node>>, GltfLoadError<E>> {

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -209,7 +209,7 @@ where
 
     loaded.nodes = load_gltf_nodes(
         renderer,
-        &mut loaded,
+        &loaded,
         scene.nodes(),
         Mat4::from_scale(Vec3::new(1.0, 1.0, -1.0)),
     )?;


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [ ] ~~changes added to changelog~~

*NOTE:* I don't think this tiny change should make it into the changelog, but let me know in case you want me to do it :+1: 

## Problems PR Solves
This is a very simple change. The `load_gltf_nodes` function borrows the loaded gltf scene mutably. I don't think this function should be able to modify the loaded scene, given its purpose, so it's best to reflect that in the contract.

## Related Issues
None, that I know of