### PR TITLE
Allow retrieving data from object manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ### Added
 - rend3-egui: An integration with the immediate mode GUI [egui](https://github.com/emilk/egui) @MindSwipe
 - rend3-textured-quad: Add example of simple 2D rendering.
+- rend3: Add methods to query the objects inside an object manager. @setzer22
 
 ### Changes
 - rend3: Instead of passing a render routine to the render function, you now add them to a rendergraph, then pass that rendergraph into the renderer.

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -128,6 +128,21 @@ impl ObjectManager {
             })
             .unwrap_or(&mut [])
     }
+
+    pub fn get_material_handle(&self, handle: RawObjectHandle) -> MaterialHandle {
+        let object = self.registry.get_value(handle);
+        object.material_handle.clone()
+    }
+
+    pub fn get_mesh_handle(&self, handle: RawObjectHandle) -> MeshHandle {
+        let object = self.registry.get_value(handle);
+        object.mesh_handle.clone()
+    }
+
+    pub fn get_transform(&self, handle: RawObjectHandle) -> Mat4 {
+        let object = self.registry.get_value(handle);
+        object.input.transform
+    }
 }
 
 impl Default for ObjectManager {

--- a/rend3/src/util/registry/archetypical.rs
+++ b/rend3/src/util/registry/archetypical.rs
@@ -135,6 +135,11 @@ where
         &mut self.archetype_map.get_mut(&handle_info.key).unwrap().data[handle_info.index]
     }
 
+    pub fn get_value(&self, handle: RawResourceHandle<HandleType>) -> &V {
+        let handle_info = &self.handle_info[&handle.idx];
+        &self.archetype_map.get(&handle_info.key).unwrap().data[handle_info.index]
+    }
+
     pub fn get_archetype_vector(&self, key: &K) -> Option<&[V]> {
         Some(&self.archetype_map.get(key)?.data)
     }


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Problems PR Solves
I found myself in the need for this when I was trying to duplicate objects. The use-case behind object duplication is to create an object and change its material, so I could do a second render pass on it for the second material. 

AFAIK, there is currently no mechanism to get the Transform, Mesh and Material handles given an ObjectHandle.

## Related Issues
None, that I know of.