### PR TITLE
Implement object duplication instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ### Added
 - rend3-egui: An integration with the immediate mode GUI [egui](https://github.com/emilk/egui) @MindSwipe
 - rend3-textured-quad: Add example of simple 2D rendering.
+- rend3: Allow duplicating objects overriding some of their properties. @setzer22
 
 ### Changes
 - rend3: Instead of passing a render routine to the render function, you now add them to a rendergraph, then pass that rendergraph into the renderer.

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -844,12 +844,13 @@ pub trait Material: Send + Sync + 'static {
     fn to_data(&self, slice: &mut [u8]);
 }
 
-/// An object in the world that is composed of a [`Mesh`] and [`Material`].
-#[derive(Debug, Clone)]
-pub struct Object {
-    pub mesh: MeshHandle,
-    pub material: MaterialHandle,
-    pub transform: Mat4,
+changeable_struct! {
+    /// An object in the world that is composed of a [`Mesh`] and [`Material`].
+    pub struct Object <- ObjectChange {
+        pub mesh: MeshHandle,
+        pub material: MaterialHandle,
+        pub transform: Mat4,
+    }
 }
 
 /// Describes how the camera should look at the scene.

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use glam::Mat4;
 use parking_lot::Mutex;
-use rend3_types::{MaterialHandle, MeshHandle, ObjectHandle, RawDirectionalLightHandle, TextureHandle};
+use rend3_types::{MaterialHandle, MeshHandle, ObjectHandle, RawDirectionalLightHandle, TextureHandle, ObjectChange};
 use std::{mem, panic::Location};
 use wgpu::{CommandBuffer, Device, Texture, TextureDescriptor, TextureView};
 
@@ -73,9 +73,7 @@ pub enum InstructionKind {
     DuplicateObject {
         src_handle: ObjectHandle,
         dst_handle: ObjectHandle,
-        material_override: Option<MaterialHandle>,
-        transform_override: Option<Mat4>,
-        mesh_override: Option<MeshHandle>,
+        change: ObjectChange,
     },
 }
 

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use glam::Mat4;
 use parking_lot::Mutex;
-use rend3_types::{MaterialHandle, MeshHandle, ObjectHandle, RawDirectionalLightHandle, TextureHandle, ObjectChange};
+use rend3_types::{MaterialHandle, MeshHandle, ObjectChange, ObjectHandle, RawDirectionalLightHandle, TextureHandle};
 use std::{mem, panic::Location};
 use wgpu::{CommandBuffer, Device, Texture, TextureDescriptor, TextureView};
 

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -70,6 +70,13 @@ pub enum InstructionKind {
     SetCameraData {
         data: Camera,
     },
+    DuplicateObject {
+        src_handle: ObjectHandle,
+        dst_handle: ObjectHandle,
+        material_override: Option<MaterialHandle>,
+        transform_override: Option<Mat4>,
+        mesh_override: Option<MeshHandle>,
+    },
 }
 
 pub struct InstructionStreamPair {

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -9,7 +9,7 @@ use crate::{
     util::{frustum::BoundingSphere, registry::ArchetypicalRegistry},
 };
 use glam::{Mat4, Vec3A};
-use rend3_types::{Material, MaterialHandle, MeshHandle, RawObjectHandle};
+use rend3_types::{Material, MaterialHandle, MeshHandle, RawObjectHandle, ObjectChange};
 
 #[repr(C, align(16))]
 #[derive(Debug, Copy, Clone)]
@@ -134,22 +134,19 @@ impl ObjectManager {
             .unwrap_or(&mut [])
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn duplicate_object(
         &mut self,
         src_handle: ObjectHandle,
         dst_handle: ObjectHandle,
-        material_override: Option<MaterialHandle>,
-        transform_override: Option<Mat4>,
-        mesh_override: Option<MeshHandle>,
+        change: ObjectChange,
         mesh_manager: &MeshManager,
         material_manager: &mut MaterialManager,
     ) {
         let src_obj = self.registry.get_value_mut(src_handle.get_raw());
         let dst_obj = Object {
-            mesh: mesh_override.unwrap_or_else(|| src_obj.mesh_handle.clone()),
-            material: material_override.unwrap_or_else(|| src_obj.material_handle.clone()),
-            transform: transform_override.unwrap_or(src_obj.input.transform),
+            mesh: change.mesh.unwrap_or_else(|| src_obj.mesh_handle.clone()),
+            material: change.material.unwrap_or_else(|| src_obj.material_handle.clone()),
+            transform: change.transform.unwrap_or(src_obj.input.transform),
         };
         self.fill(&dst_handle, dst_obj, mesh_manager, material_manager);
     }

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -133,6 +133,25 @@ impl ObjectManager {
             })
             .unwrap_or(&mut [])
     }
+
+    pub fn duplicate_object(
+        &mut self,
+        src_handle: ObjectHandle,
+        dst_handle: ObjectHandle,
+        material_override: Option<MaterialHandle>,
+        transform_override: Option<Mat4>,
+        mesh_override: Option<MeshHandle>,
+        mesh_manager: &MeshManager,
+        material_manager: &mut MaterialManager,
+    ) {
+        let src_obj = self.registry.get_value_mut(src_handle.get_raw());
+        let dst_obj = Object {
+            mesh: mesh_override.unwrap_or_else(|| src_obj.mesh_handle.clone()),
+            material: material_override.unwrap_or_else(|| src_obj.material_handle.clone()),
+            transform: transform_override.unwrap_or(src_obj.input.transform),
+        };
+        self.fill(&dst_handle, dst_obj, mesh_manager, material_manager);
+    }
 }
 
 impl Default for ObjectManager {

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -134,6 +134,7 @@ impl ObjectManager {
             .unwrap_or(&mut [])
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn duplicate_object(
         &mut self,
         src_handle: ObjectHandle,

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -9,7 +9,7 @@ use crate::{
     util::{frustum::BoundingSphere, registry::ArchetypicalRegistry},
 };
 use glam::{Mat4, Vec3A};
-use rend3_types::{Material, MaterialHandle, MeshHandle, RawObjectHandle, ObjectChange};
+use rend3_types::{Material, MaterialHandle, MeshHandle, ObjectChange, RawObjectHandle};
 
 #[repr(C, align(16))]
 #[derive(Debug, Copy, Clone)]

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 use glam::Mat4;
 use parking_lot::Mutex;
-use rend3_types::{Handedness, Material, MipmapCount, MipmapSource, TextureFormat, TextureFromTexture, TextureUsages, ObjectChange};
+use rend3_types::{
+    Handedness, Material, MipmapCount, MipmapSource, ObjectChange, TextureFormat, TextureFromTexture, TextureUsages,
+};
 use std::{
     num::NonZeroU32,
     panic::Location,
@@ -414,11 +416,7 @@ impl Renderer {
     /// object's handle. The duplicated object will reference the same mesh,
     /// material and transform as the original object.
     #[track_caller]
-    pub fn duplicate_object(
-        &self,
-        object_handle: &ObjectHandle,
-        change: ObjectChange,
-    ) -> ObjectHandle {
+    pub fn duplicate_object(&self, object_handle: &ObjectHandle, change: ObjectChange) -> ObjectHandle {
         let dst_handle = ObjectManager::allocate(&self.current_ident);
         self.instructions.push(
             InstructionKind::DuplicateObject {

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -413,8 +413,9 @@ impl Renderer {
     }
 
     /// Duplicates an existing object in the renderer, returning the new
-    /// object's handle. The duplicated object will reference the same mesh,
-    /// material and transform as the original object.
+    /// object's handle. Any changes specified in the `change` struct will be
+    /// applied to the duplicated object, and the same mesh, material and
+    /// transform as the original object will be used otherwise.
     #[track_caller]
     pub fn duplicate_object(&self, object_handle: &ObjectHandle, change: ObjectChange) -> ObjectHandle {
         let dst_handle = ObjectManager::allocate(&self.current_ident);

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -410,6 +410,31 @@ impl Renderer {
         handle
     }
 
+    /// Duplicates an existing object in the renderer, returning the new
+    /// object's handle. The duplicated object will reference the same mesh,
+    /// material and transform as the original object.
+    #[track_caller]
+    pub fn duplicate_object(
+        &self,
+        object_handle: &ObjectHandle,
+        material_override: Option<MaterialHandle>,
+        transform_override: Option<Mat4>,
+        mesh_override: Option<MeshHandle>,
+    ) -> ObjectHandle {
+        let dst_handle = ObjectManager::allocate(&self.current_ident);
+        self.instructions.push(
+            InstructionKind::DuplicateObject {
+                src_handle: object_handle.clone(),
+                dst_handle: dst_handle.clone(),
+                material_override,
+                transform_override,
+                mesh_override,
+            },
+            *Location::caller(),
+        );
+        dst_handle
+    }
+
     /// Move the given object to a new transform location.
     #[track_caller]
     pub fn set_object_transform(&self, handle: &ObjectHandle, transform: Mat4) {

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use glam::Mat4;
 use parking_lot::Mutex;
-use rend3_types::{Handedness, Material, MipmapCount, MipmapSource, TextureFormat, TextureFromTexture, TextureUsages};
+use rend3_types::{Handedness, Material, MipmapCount, MipmapSource, TextureFormat, TextureFromTexture, TextureUsages, ObjectChange};
 use std::{
     num::NonZeroU32,
     panic::Location,
@@ -417,18 +417,14 @@ impl Renderer {
     pub fn duplicate_object(
         &self,
         object_handle: &ObjectHandle,
-        material_override: Option<MaterialHandle>,
-        transform_override: Option<Mat4>,
-        mesh_override: Option<MeshHandle>,
+        change: ObjectChange,
     ) -> ObjectHandle {
         let dst_handle = ObjectManager::allocate(&self.current_ident);
         self.instructions.push(
             InstructionKind::DuplicateObject {
                 src_handle: object_handle.clone(),
                 dst_handle: dst_handle.clone(),
-                material_override,
-                transform_override,
-                mesh_override,
+                change,
             },
             *Location::caller(),
         );

--- a/rend3/src/renderer/ready.rs
+++ b/rend3/src/renderer/ready.rs
@@ -98,16 +98,12 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                 InstructionKind::DuplicateObject {
                     src_handle,
                     dst_handle,
-                    material_override,
-                    transform_override,
-                    mesh_override,
+                    change,
                 } => {
                     data_core.object_manager.duplicate_object(
                         src_handle,
                         dst_handle,
-                        material_override,
-                        transform_override,
-                        mesh_override,
+                        change,
                         &data_core.mesh_manager,
                         &mut data_core.material_manager,
                     );

--- a/rend3/src/renderer/ready.rs
+++ b/rend3/src/renderer/ready.rs
@@ -95,6 +95,23 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                 InstructionKind::SetCameraData { data } => {
                     data_core.camera_manager.set_data(data);
                 }
+                InstructionKind::DuplicateObject {
+                    src_handle,
+                    dst_handle,
+                    material_override,
+                    transform_override,
+                    mesh_override,
+                } => {
+                    data_core.object_manager.duplicate_object(
+                        src_handle,
+                        dst_handle,
+                        material_override,
+                        transform_override,
+                        mesh_override,
+                        &data_core.mesh_manager,
+                        &mut data_core.material_manager,
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Problems PR Solves
Sometimes it is desirable to duplicate an object. A good example is duplicating an object and changing its material to do a second render pass with a different shader.

This PR implements a `duplicate_object` function, which internally implements an `InstructionKind::DuplicateObject`. Overrides are possible for all the three fields of an Object (mesh, material and transform).

## Related Issues
None that I'm aware of. But this is an alternative solution to the problem solved by PR #305