### PR TITLE
Add the Skeleton type and its SkeletonManager 🦴

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3: Add `CameraProjection::Raw`.
 - rend3-routine: All transparency now has backface culling enabled. Use `Mesh::double_side` or `MeshBuilder::with_double_side` to re-enable double sided transparency.
 - rend3: Allow requesting device features explicitly in `rend3::create_iad`. @setzer22
+- rend3: Objects now take a `mesk_kind` allowind definition of static or animated meshes. @setzer22
 
 ### Fixes
 - rend3: Get vertex/index counts from RangeAllocator. @jamen

--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -120,7 +120,7 @@ fn main() {
 
     // Combine the mesh and the material with a location to give an object.
     let object = rend3::types::Object {
-        mesh: mesh_handle,
+        mesh_kind: rend3::types::ObjectMeshKind::Static(mesh_handle),
         material: material_handle,
         transform: glam::Mat4::IDENTITY,
     };

--- a/examples/cube/src/lib.rs
+++ b/examples/cube/src/lib.rs
@@ -93,7 +93,7 @@ impl rend3_framework::App for CubeExample {
 
         // Combine the mesh and the material with a location to give an object.
         let object = rend3::types::Object {
-            mesh: mesh_handle,
+            mesh_kind: rend3::types::ObjectMeshKind::Static(mesh_handle),
             material: material_handle,
             transform: glam::Mat4::IDENTITY,
         };

--- a/examples/egui/src/main.rs
+++ b/examples/egui/src/main.rs
@@ -61,7 +61,7 @@ impl rend3_framework::App for EguiExample {
 
         // Combine the mesh and the material with a location to give an object.
         let object = rend3::types::Object {
-            mesh: mesh_handle,
+            mesh_kind: rend3::types::ObjectMeshKind::Static(mesh_handle),
             material: material_handle.clone(),
             transform: glam::Mat4::IDENTITY,
         };

--- a/examples/gltf/src/main.rs
+++ b/examples/gltf/src/main.rs
@@ -78,7 +78,7 @@ impl rend3_framework::App for GltfExample {
 
         // Combine the mesh and the material with a location to give an object.
         let object = rend3::types::Object {
-            mesh,
+            mesh_kind: rend3::types::ObjectMeshKind::Static(mesh),
             material,
             transform: glam::Mat4::from_scale(glam::Vec3::new(1.0, 1.0, -1.0)),
         };

--- a/examples/imgui/src/main.rs
+++ b/examples/imgui/src/main.rs
@@ -73,7 +73,7 @@ impl rend3_framework::App for ImguiExample {
 
         // Combine the mesh and the material with a location to give an object.
         let object = rend3::types::Object {
-            mesh: mesh_handle,
+            mesh_kind: rend3::types::ObjectMeshKind::Static(mesh_handle),
             material: material_handle,
             transform: glam::Mat4::IDENTITY,
         };

--- a/examples/textured-quad/src/main.rs
+++ b/examples/textured-quad/src/main.rs
@@ -88,7 +88,7 @@ impl rend3_framework::App for TexturedQuadExample {
 
         // Combine the mesh and the material with a location to give an object.
         let object = rend3::types::Object {
-            mesh: mesh_handle,
+            mesh_kind: rend3::types::ObjectMeshKind::Static(mesh_handle),
             material: material_handle,
             transform: glam::Mat4::from_scale_rotation_translation(
                 glam::Vec3::new(1.0, 1.0, 1.0),

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -161,8 +161,8 @@ pub enum GltfLoadError<E: std::error::Error + 'static> {
 pub async fn filesystem_io_func(parent_directory: impl AsRef<Path>, uri: SsoString) -> Result<Vec<u8>, std::io::Error> {
     let octet_stream_header = "data:";
     if let Some(base64_data) = uri.strip_prefix(octet_stream_header) {
-        let (_mime, rest) = base64_data.split_once(";").unwrap();
-        let (encoding, data) = rest.split_once(",").unwrap();
+        let (_mime, rest) = base64_data.split_once(';').unwrap();
+        let (encoding, data) = rest.split_once(',').unwrap();
         assert_eq!(encoding, "base64");
         // profiling::scope!("decoding base64 uri");
         log::info!("loading {} bytes of base64 data", data.len());

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -24,7 +24,7 @@ use glam::{Mat3, Mat4, UVec2, Vec2, Vec3, Vec4};
 use gltf::buffer::Source;
 use image::GenericImageView;
 use rend3::{
-    types::{self, Handedness, MeshValidationError, ObjectHandle},
+    types::{self, Handedness, MeshValidationError, ObjectHandle, ObjectMeshKind},
     util::typedefs::{FastHashMap, SsoString},
     Renderer,
 };
@@ -307,7 +307,8 @@ pub fn add_mesh_by_index<E: std::error::Error + 'static>(
                 )
                 .ok_or_else(|| GltfLoadError::MissingMaterial(mat_idx.expect("Could not find default material")))?;
             Ok(renderer.add_object(types::Object {
-                mesh: prim.handle.clone(),
+                // TODO: Autodetect animation and spawn skeleton instead.
+                mesh_kind: ObjectMeshKind::Static(prim.handle.clone()),
                 material: mat.clone(),
                 transform,
             }))

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -943,8 +943,25 @@ pub struct Skeleton {
     /// corresponding joint. Not to be confused with the transform matrix of the
     /// joint itself.
     ///
-    /// TODO: Add note about utility function that takes inverseBindMatrices and
-    /// how to use it.
+    /// The `Skeleton::form_joint_transforms` constructor can be used to create
+    /// a Skeleton with the joint transform matrices instead.
     pub joint_deltas: Vec<Mat4>,
     pub mesh: MeshHandle,
+}
+
+impl Skeleton {
+    /// Creates a skeleton with the list of global transforms and inverse bind
+    /// transforms for each joint
+    pub fn from_joint_transforms(
+        mesh: MeshHandle,
+        joint_global_transforms: &[Mat4],
+        inverse_bind_transforms: &[Mat4],
+    ) -> Skeleton {
+        let joint_deltas: Vec<Mat4> = joint_global_transforms
+            .iter()
+            .zip(inverse_bind_transforms.iter())
+            .map(|(global_pos, inv_bind_pos)| (*global_pos) * (*inv_bind_pos))
+            .collect();
+        Skeleton { joint_deltas, mesh }
+    }
 }

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -130,7 +130,8 @@ declare_handle!(
     TextureHandle<Texture>,
     MaterialHandle<MaterialTag>,
     ObjectHandle<Object>,
-    DirectionalLightHandle<DirectionalLight>
+    DirectionalLightHandle<DirectionalLight>,
+    SkeletonHandle<Skeleton>
 );
 
 #[macro_export]
@@ -147,7 +148,8 @@ declare_raw_handle!(
     RawTextureHandle<Texture>,
     RawMaterialHandle<MaterialTag>,
     RawObjectHandle<Object>,
-    RawDirectionalLightHandle<DirectionalLight>
+    RawDirectionalLightHandle<DirectionalLight>,
+    RawSkeletonHandle<Skeleton>
 );
 
 macro_rules! changeable_struct {
@@ -925,4 +927,17 @@ impl Default for Handedness {
     fn default() -> Self {
         Self::Left
     }
+}
+
+/// A Skeleton stores the necessary data to do vertex skinning for an [Object]
+#[derive(Debug, Clone)]
+pub struct Skeleton {
+    /// Stores one transformation matrix for each joint. These are the
+    /// transformations that will be applied to the vertices affected by the
+    /// corresponding joint. Not to be confused with the transform matrix of the
+    /// joint itself.
+    ///
+    /// TODO: Add note about utility function that takes inverseBindMatrices and
+    /// how to use it.
+    pub joint_deltas: Vec<Mat4>,
 }

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -957,11 +957,17 @@ impl Skeleton {
         joint_global_transforms: &[Mat4],
         inverse_bind_transforms: &[Mat4],
     ) -> Skeleton {
-        let joint_deltas: Vec<Mat4> = joint_global_transforms
+        let joint_deltas = Self::compute_joint_matrices(joint_global_transforms, inverse_bind_transforms);
+        Skeleton { joint_deltas, mesh }
+    }
+
+    /// Given a list of joint global positions and another one with inverse bind
+    /// matrices, multiplies them together to return the list of joint matrices.
+    pub fn compute_joint_matrices(joint_global_transforms: &[Mat4], inverse_bind_transforms: &[Mat4]) -> Vec<Mat4> {
+        joint_global_transforms
             .iter()
             .zip(inverse_bind_transforms.iter())
             .map(|(global_pos, inv_bind_pos)| (*global_pos) * (*inv_bind_pos))
-            .collect();
-        Skeleton { joint_deltas, mesh }
+            .collect()
     }
 }

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -833,10 +833,16 @@ pub trait Material: Send + Sync + 'static {
     fn to_data(&self, slice: &mut [u8]);
 }
 
+#[derive(Clone, Debug)]
+pub enum ObjectMeshKind {
+    Animated(SkeletonHandle),
+    Static(MeshHandle),
+}
+
 changeable_struct! {
     /// An object in the world that is composed of a [`Mesh`] and [`Material`].
     pub struct Object <- ObjectChange {
-        pub mesh: MeshHandle,
+        pub mesh_kind: ObjectMeshKind,
         pub material: MaterialHandle,
         pub transform: Mat4,
     }
@@ -940,4 +946,5 @@ pub struct Skeleton {
     /// TODO: Add note about utility function that takes inverseBindMatrices and
     /// how to use it.
     pub joint_deltas: Vec<Mat4>,
+    pub mesh: MeshHandle,
 }

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use glam::Mat4;
 use parking_lot::Mutex;
-use rend3_types::{MaterialHandle, MeshHandle, ObjectChange, ObjectHandle, RawDirectionalLightHandle, TextureHandle};
+use rend3_types::{
+    MaterialHandle, MeshHandle, ObjectChange, ObjectHandle, RawDirectionalLightHandle, Skeleton, SkeletonHandle,
+    TextureHandle, RawSkeletonHandle,
+};
 use std::{mem, panic::Location};
 use wgpu::{CommandBuffer, Device, Texture, TextureDescriptor, TextureView};
 
@@ -19,6 +22,10 @@ pub enum InstructionKind {
     AddMesh {
         handle: MeshHandle,
         mesh: Mesh,
+    },
+    AddSkeleton {
+        handle: SkeletonHandle,
+        skeleton: Skeleton,
     },
     AddTexture {
         handle: TextureHandle,
@@ -55,6 +62,10 @@ pub enum InstructionKind {
     SetObjectTransform {
         handle: RawObjectHandle,
         transform: Mat4,
+    },
+    SetSkeletonJointDeltas {
+        handle: RawSkeletonHandle,
+        joint_deltas: Vec<Mat4>,
     },
     AddDirectionalLight {
         handle: DirectionalLightHandle,

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -6,8 +6,8 @@ use crate::{
 use glam::Mat4;
 use parking_lot::Mutex;
 use rend3_types::{
-    MaterialHandle, MeshHandle, ObjectChange, ObjectHandle, RawDirectionalLightHandle, Skeleton, SkeletonHandle,
-    TextureHandle, RawSkeletonHandle,
+    MaterialHandle, MeshHandle, ObjectChange, ObjectHandle, RawDirectionalLightHandle, RawSkeletonHandle, Skeleton,
+    SkeletonHandle, TextureHandle,
 };
 use std::{mem, panic::Location};
 use wgpu::{CommandBuffer, Device, Texture, TextureDescriptor, TextureView};

--- a/rend3/src/lib.rs
+++ b/rend3/src/lib.rs
@@ -81,6 +81,7 @@ pub mod managers {
     mod material;
     mod mesh;
     mod object;
+    mod skeleton;
     mod texture;
 
     pub use camera::*;
@@ -88,6 +89,7 @@ pub mod managers {
     pub use material::*;
     pub use mesh::*;
     pub use object::*;
+    pub use skeleton::*;
     pub use texture::*;
 }
 

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -229,6 +229,97 @@ impl MeshManager {
         self.registry.insert(handle, mesh);
     }
 
+    /// Duplicates a mesh's vertex data so that it can be skinned on the GPU.
+    pub fn allocate_skeleton_mesh(
+        &mut self,
+        device: &Device,
+        _queue: &Queue,
+        encoder: &mut CommandEncoder,
+        mesh_handle: &MeshHandle,
+    ) -> Range<usize> {
+        // Need to fetch internal data twice, because the returned mesh borrows &self
+        let needed_verts = self.internal_data(mesh_handle.get_raw()).vertex_range.len();
+        let vertex_range = match self.vertex_alloc.allocate_range(needed_verts) {
+            Ok(range) => range,
+            Err(_) => {
+                self.reallocate_buffers(device, encoder, needed_verts as u32, 0);
+                self.vertex_alloc
+                    .allocate_range(needed_verts)
+                    .expect("We just reallocated")
+            }
+        };
+
+        let original = self.internal_data(mesh_handle.get_raw());
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_position,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_position,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_POSITION_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_normal,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_normal,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_NORMAL_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_tangent,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_tangent,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_TANGENT_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_uv0,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_uv0,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_UV_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_uv1,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_uv1,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_UV_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_color,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_color,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_COLOR_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_joint_index,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_joint_index,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_JOINT_INDEX_SIZE) as u64,
+        );
+
+        encoder.copy_buffer_to_buffer(
+            &self.buffers.vertex_joint_weight,
+            original.vertex_range.start as u64,
+            &self.buffers.vertex_joint_weight,
+            vertex_range.start as u64,
+            (vertex_range.len() * VERTEX_JOINT_WEIGHT_SIZE) as u64,
+        );
+
+        // TODO: When do we copy the object index buffer (GPU mode)?
+
+        vertex_range
+    }
+
     pub fn buffers(&self) -> &MeshBuffers {
         &self.buffers
     }

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -255,7 +255,7 @@ impl MeshManager {
             &self.buffers.vertex_position,
             (original.vertex_range.start * VERTEX_POSITION_SIZE) as u64,
             &self.buffers.vertex_position,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_POSITION_SIZE) as u64,
             (vertex_range.len() * VERTEX_POSITION_SIZE) as u64,
         );
 
@@ -263,7 +263,7 @@ impl MeshManager {
             &self.buffers.vertex_normal,
             (original.vertex_range.start * VERTEX_NORMAL_SIZE) as u64,
             &self.buffers.vertex_normal,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_NORMAL_SIZE) as u64,
             (vertex_range.len() * VERTEX_NORMAL_SIZE) as u64,
         );
 
@@ -271,7 +271,7 @@ impl MeshManager {
             &self.buffers.vertex_tangent,
             (original.vertex_range.start * VERTEX_TANGENT_SIZE) as u64,
             &self.buffers.vertex_tangent,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_TANGENT_SIZE) as u64,
             (vertex_range.len() * VERTEX_TANGENT_SIZE) as u64,
         );
 
@@ -279,7 +279,7 @@ impl MeshManager {
             &self.buffers.vertex_uv0,
             (original.vertex_range.start * VERTEX_UV_SIZE) as u64,
             &self.buffers.vertex_uv0,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_UV_SIZE) as u64,
             (vertex_range.len() * VERTEX_UV_SIZE) as u64,
         );
 
@@ -287,7 +287,7 @@ impl MeshManager {
             &self.buffers.vertex_uv1,
             (original.vertex_range.start * VERTEX_UV_SIZE) as u64,
             &self.buffers.vertex_uv1,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_UV_SIZE) as u64,
             (vertex_range.len() * VERTEX_UV_SIZE) as u64,
         );
 
@@ -295,7 +295,7 @@ impl MeshManager {
             &self.buffers.vertex_color,
             (original.vertex_range.start * VERTEX_COLOR_SIZE) as u64,
             &self.buffers.vertex_color,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_COLOR_SIZE) as u64,
             (vertex_range.len() * VERTEX_COLOR_SIZE) as u64,
         );
 
@@ -303,7 +303,7 @@ impl MeshManager {
             &self.buffers.vertex_joint_index,
             (original.vertex_range.start * VERTEX_JOINT_INDEX_SIZE) as u64,
             &self.buffers.vertex_joint_index,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_JOINT_INDEX_SIZE) as u64,
             (vertex_range.len() * VERTEX_JOINT_INDEX_SIZE) as u64,
         );
 
@@ -311,7 +311,7 @@ impl MeshManager {
             &self.buffers.vertex_joint_weight,
             (original.vertex_range.start * VERTEX_JOINT_WEIGHT_SIZE) as u64,
             &self.buffers.vertex_joint_weight,
-            vertex_range.start as u64,
+            (vertex_range.start * VERTEX_JOINT_WEIGHT_SIZE) as u64,
             (vertex_range.len() * VERTEX_JOINT_WEIGHT_SIZE) as u64,
         );
 

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -253,7 +253,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_position,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_POSITION_SIZE) as u64,
             &self.buffers.vertex_position,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_POSITION_SIZE) as u64,
@@ -261,7 +261,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_normal,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_NORMAL_SIZE) as u64,
             &self.buffers.vertex_normal,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_NORMAL_SIZE) as u64,
@@ -269,7 +269,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_tangent,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_TANGENT_SIZE) as u64,
             &self.buffers.vertex_tangent,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_TANGENT_SIZE) as u64,
@@ -277,7 +277,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_uv0,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_UV_SIZE) as u64,
             &self.buffers.vertex_uv0,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_UV_SIZE) as u64,
@@ -285,7 +285,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_uv1,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_UV_SIZE) as u64,
             &self.buffers.vertex_uv1,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_UV_SIZE) as u64,
@@ -293,7 +293,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_color,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_COLOR_SIZE) as u64,
             &self.buffers.vertex_color,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_COLOR_SIZE) as u64,
@@ -301,7 +301,7 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_joint_index,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_JOINT_INDEX_SIZE) as u64,
             &self.buffers.vertex_joint_index,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_JOINT_INDEX_SIZE) as u64,
@@ -309,13 +309,11 @@ impl MeshManager {
 
         encoder.copy_buffer_to_buffer(
             &self.buffers.vertex_joint_weight,
-            original.vertex_range.start as u64,
+            (original.vertex_range.start * VERTEX_JOINT_WEIGHT_SIZE) as u64,
             &self.buffers.vertex_joint_weight,
             vertex_range.start as u64,
             (vertex_range.len() * VERTEX_JOINT_WEIGHT_SIZE) as u64,
         );
-
-        // TODO: When do we copy the object index buffer (GPU mode)?
 
         vertex_range
     }

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -426,6 +426,22 @@ impl MeshManager {
                 &new_vert_range,
                 VERTEX_COLOR_SIZE,
             );
+            copy_vert(
+                encoder,
+                &self.buffers.vertex_joint_index,
+                &new_buffers.vertex_joint_index,
+                mesh,
+                &new_vert_range,
+                VERTEX_JOINT_WEIGHT_SIZE,
+            );
+            copy_vert(
+                encoder,
+                &self.buffers.vertex_joint_weight,
+                &new_buffers.vertex_joint_weight,
+                mesh,
+                &new_vert_range,
+                VERTEX_JOINT_INDEX_SIZE,
+            );
 
             // Copy indices over to new buffer, adjusting their value by the difference
             let index_copy_start = mesh.index_range.start * INDEX_SIZE;

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -9,7 +9,7 @@ use crate::{
     util::{frustum::BoundingSphere, registry::ArchetypicalRegistry},
 };
 use glam::{Mat4, Vec3A};
-use rend3_types::{Material, MaterialHandle, MeshHandle, ObjectChange, RawObjectHandle, SkeletonHandle, ObjectMeshKind};
+use rend3_types::{Material, MaterialHandle, ObjectChange, RawObjectHandle, ObjectMeshKind};
 
 use super::SkeletonManager;
 

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -9,7 +9,7 @@ use crate::{
     util::{frustum::BoundingSphere, registry::ArchetypicalRegistry},
 };
 use glam::{Mat4, Vec3A};
-use rend3_types::{Material, MaterialHandle, ObjectChange, RawObjectHandle, ObjectMeshKind};
+use rend3_types::{Material, MaterialHandle, ObjectChange, ObjectMeshKind, RawObjectHandle};
 
 use super::SkeletonManager;
 
@@ -76,12 +76,20 @@ impl ObjectManager {
             ObjectMeshKind::Animated(skeleton) => {
                 let skeleton = skeleton_manager.internal_data(skeleton.get_raw());
                 let mesh = mesh_manager.internal_data(skeleton.mesh_handle.get_raw());
-                (mesh.bounding_sphere, mesh.index_range.clone(), skeleton.vertex_range.clone())
-            },
+                (
+                    mesh.bounding_sphere,
+                    mesh.index_range.clone(),
+                    skeleton.vertex_range.clone(),
+                )
+            }
             ObjectMeshKind::Static(mesh) => {
                 let mesh = mesh_manager.internal_data(mesh.get_raw());
-                (mesh.bounding_sphere, mesh.index_range.clone(), mesh.vertex_range.clone())
-            },
+                (
+                    mesh.bounding_sphere,
+                    mesh.index_range.clone(),
+                    mesh.vertex_range.clone(),
+                )
+            }
         };
 
         let (material_key, object_list) = material_manager.get_material_key_and_objects(object.material.get_raw());

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -1,0 +1,62 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::util::registry::ResourceRegistry;
+
+use glam::Mat4;
+use rend3_types::{RawSkeletonHandle, Skeleton, SkeletonHandle};
+
+/// Internal representation of a Skeleton
+#[repr(C, align(16))]
+#[derive(Debug, Clone)]
+pub struct InternalSkeleton {
+    /// Stores one transformation matrix for each joint. These are the
+    /// transformations that will be applied to the vertices affected by the
+    /// corresponding joint. Not to be confused with the transform matrix of the
+    /// joint itself.
+    /// TODO: Add note about utility function that takes inverseBindMatrices
+    pub joint_deltas: Vec<Mat4>,
+}
+
+/// Manages skeletons. Skeletons only contain the relevant data for vertex
+/// skinning. No bone hierarchy is stored.
+pub struct SkeletonManager {
+    registry: ResourceRegistry<InternalSkeleton, Skeleton>,
+}
+impl SkeletonManager {
+    pub fn new() -> Self {
+        profiling::scope!("SkeletonManager::new");
+
+        let registry = ResourceRegistry::new();
+
+        Self { registry }
+    }
+
+    pub fn allocate(counter: &AtomicUsize) -> SkeletonHandle {
+        let idx = counter.fetch_add(1, Ordering::Relaxed);
+
+        SkeletonHandle::new(idx)
+    }
+
+    pub fn fill(&mut self, handle: &SkeletonHandle, skeleton: Skeleton) {
+        let internal = InternalSkeleton {
+            joint_deltas: skeleton.joint_deltas,
+        };
+        self.registry.insert(handle, internal);
+    }
+
+    pub fn ready(&mut self) {
+        profiling::scope!("Skeleton Manager Ready");
+        self.registry.remove_all_dead(|_, _, _| {});
+    }
+
+    pub fn set_joint_deltas(&mut self, handle: RawSkeletonHandle, joint_deltas: Vec<Mat4>) {
+        let skeleton = self.registry.get_mut(handle);
+        skeleton.joint_deltas = joint_deltas;
+    }
+}
+
+impl Default for SkeletonManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -59,11 +59,7 @@ impl SkeletonManager {
         self.registry.insert(handle, internal);
     }
 
-    pub fn set_skeleton_joint_deltas(
-        &mut self,
-        handle: RawSkeletonHandle,
-        joint_deltas: Vec<Mat4>,
-    ) {
+    pub fn set_skeleton_joint_deltas(&mut self, handle: RawSkeletonHandle, joint_deltas: Vec<Mat4>) {
         let skeleton = self.registry.get_mut(handle);
         skeleton.joint_deltas = joint_deltas;
     }

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -10,8 +10,7 @@ use rend3_types::{MeshHandle, RawSkeletonHandle, Skeleton, SkeletonHandle};
 use wgpu::{CommandEncoder, Device, Queue};
 
 /// Internal representation of a Skeleton
-#[repr(C, align(16))]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct InternalSkeleton {
     pub mesh_handle: MeshHandle,
     pub joint_deltas: Vec<Mat4>,

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -3,13 +3,11 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use crate::util::registry::ResourceRegistry;
+use crate::{managers::MeshManager, util::registry::ResourceRegistry};
 
 use glam::Mat4;
 use rend3_types::{MeshHandle, RawSkeletonHandle, Skeleton, SkeletonHandle};
 use wgpu::{CommandEncoder, Device, Queue};
-
-use super::MeshManager;
 
 /// Internal representation of a Skeleton
 #[repr(C, align(16))]

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -59,6 +59,15 @@ impl SkeletonManager {
         self.registry.insert(handle, internal);
     }
 
+    pub fn set_skeleton_joint_deltas(
+        &mut self,
+        handle: RawSkeletonHandle,
+        joint_deltas: Vec<Mat4>,
+    ) {
+        let skeleton = self.registry.get_mut(handle);
+        skeleton.joint_deltas = joint_deltas;
+    }
+
     pub fn ready(&mut self) {
         profiling::scope!("Skeleton Manager Ready");
         self.registry.remove_all_dead(|_, _, _| {});

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -471,15 +471,13 @@ impl Renderer {
     pub fn set_skeleton_joint_transforms(
         &self,
         handle: &SkeletonHandle,
-        joint_global_positions: &[Mat4],
-        inverse_bind_poses: &[Mat4],
+        joint_global_transforms: &[Mat4],
+        inverse_bind_transforms: &[Mat4],
     ) {
-        let joint_deltas: Vec<Mat4> = joint_global_positions
-            .iter()
-            .zip(inverse_bind_poses.iter())
-            .map(|(global_pos, inv_bind_pos)| (*global_pos) * (*inv_bind_pos))
-            .collect();
-        self.set_skeleton_joint_deltas(handle, joint_deltas);
+        self.set_skeleton_joint_deltas(
+            handle,
+            Skeleton::compute_joint_matrices(joint_global_transforms, inverse_bind_transforms),
+        );
     }
 
     /// Sets the joint deltas for a skeleton. The joint delta is the
@@ -487,6 +485,7 @@ impl Renderer {
     /// Note that this is not the same as the joint's transformation. See
     /// [Renderer::set_skeleton_joint_positions] for an alternative method that
     /// allows setting the joint transformation instead.
+    #[track_caller]
     pub fn set_skeleton_joint_deltas(&self, handle: &SkeletonHandle, joint_deltas: Vec<Mat4>) {
         self.instructions.push(
             InstructionKind::SetSkeletonJointDeltas {

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     instruction::{InstructionKind, InstructionStreamPair},
     managers::{
         CameraManager, DirectionalLightManager, InternalTexture, MaterialManager, MeshManager, ObjectManager,
-        TextureManager,
+        TextureManager, SkeletonManager,
     },
     types::{
         Camera, DirectionalLight, DirectionalLightChange, DirectionalLightHandle, MaterialHandle, Mesh, MeshHandle,
@@ -81,6 +81,8 @@ pub struct RendererDataCore {
     pub object_manager: ObjectManager,
     /// Manages all directional lights, including their shadow maps.
     pub directional_light_manager: DirectionalLightManager,
+    /// Manages skeletons, and their owned portion of the MeshManager's buffers
+    pub skeleton_manager: SkeletonManager,
 
     /// Stores gpu timing and debug scopes.
     pub profiler: GpuProfiler,

--- a/rend3/src/renderer/ready.rs
+++ b/rend3/src/renderer/ready.rs
@@ -77,6 +77,7 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                         &handle,
                         object,
                         &data_core.mesh_manager,
+                        &mut data_core.skeleton_manager,
                         &mut data_core.material_manager,
                     );
                 }
@@ -105,6 +106,7 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                         dst_handle,
                         change,
                         &data_core.mesh_manager,
+                        &mut data_core.skeleton_manager,
                         &mut data_core.material_manager,
                     );
                 }

--- a/rend3/src/renderer/ready.rs
+++ b/rend3/src/renderer/ready.rs
@@ -35,6 +35,21 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                         .fill(&renderer.device, &renderer.queue, &mut encoder, &handle, mesh);
                     data_core.profiler.end_scope(&mut encoder);
                 }
+                InstructionKind::AddSkeleton { handle, skeleton } => {
+                    profiling::scope!("Add Skeleton");
+                    data_core
+                        .profiler
+                        .begin_scope("Add Skeleton", &mut encoder, &renderer.device);
+                    data_core.skeleton_manager.fill(
+                        &renderer.device,
+                        &renderer.queue,
+                        &mut encoder,
+                        &mut data_core.mesh_manager,
+                        &handle,
+                        skeleton,
+                    );
+                    data_core.profiler.end_scope(&mut encoder);
+                }
                 InstructionKind::AddTexture {
                     handle,
                     desc,
@@ -84,6 +99,9 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                 InstructionKind::SetObjectTransform { handle, transform } => {
                     data_core.object_manager.set_object_transform(handle, transform);
                 }
+                InstructionKind::SetSkeletonJointDeltas { handle, joint_deltas } => {
+                    data_core.skeleton_manager.set_joint_deltas(handle, joint_deltas);
+                }
                 InstructionKind::AddDirectionalLight { handle, light } => {
                     data_core.directional_light_manager.fill(&handle, light);
                 }
@@ -106,7 +124,7 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                         dst_handle,
                         change,
                         &data_core.mesh_manager,
-                        &mut data_core.skeleton_manager,
+                        &data_core.skeleton_manager,
                         &mut data_core.material_manager,
                     );
                 }

--- a/rend3/src/renderer/ready.rs
+++ b/rend3/src/renderer/ready.rs
@@ -92,7 +92,7 @@ pub fn ready(renderer: &Renderer) -> (Vec<CommandBuffer>, ReadyData) {
                         &handle,
                         object,
                         &data_core.mesh_manager,
-                        &mut data_core.skeleton_manager,
+                        &data_core.skeleton_manager,
                         &mut data_core.material_manager,
                     );
                 }

--- a/rend3/src/renderer/setup.rs
+++ b/rend3/src/renderer/setup.rs
@@ -1,6 +1,6 @@
 use crate::{
     instruction::InstructionStreamPair,
-    managers::{CameraManager, DirectionalLightManager, MaterialManager, MeshManager, ObjectManager, TextureManager},
+    managers::{CameraManager, DirectionalLightManager, MaterialManager, MeshManager, ObjectManager, TextureManager, SkeletonManager},
     renderer::RendererDataCore,
     util::{graph_texture_store::GraphTextureStore, mipmap::MipmapGenerator},
     InstanceAdapterDevice, Renderer, RendererInitializationError,
@@ -39,6 +39,7 @@ pub fn create_renderer(
     let material_manager = MaterialManager::new(&iad.device, iad.mode);
     let object_manager = ObjectManager::new();
     let directional_light_manager = DirectionalLightManager::new(&iad.device);
+    let skeleton_manager = SkeletonManager::new();
 
     let mipmap_generator = MipmapGenerator::new(
         &iad.device,
@@ -75,6 +76,7 @@ pub fn create_renderer(
             material_manager,
             object_manager,
             directional_light_manager,
+            skeleton_manager,
             profiler,
             graph_texture_store: GraphTextureStore::new(),
         }),

--- a/rend3/src/renderer/setup.rs
+++ b/rend3/src/renderer/setup.rs
@@ -1,6 +1,9 @@
 use crate::{
     instruction::InstructionStreamPair,
-    managers::{CameraManager, DirectionalLightManager, MaterialManager, MeshManager, ObjectManager, TextureManager, SkeletonManager},
+    managers::{
+        CameraManager, DirectionalLightManager, MaterialManager, MeshManager, ObjectManager, SkeletonManager,
+        TextureManager,
+    },
     renderer::RendererDataCore,
     util::{graph_texture_store::GraphTextureStore, mipmap::MipmapGenerator},
     InstanceAdapterDevice, Renderer, RendererInitializationError,


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- [x] cargo clippy reports no issues
- [x] cargo deny issues have been fixed or added to deny.toml
- [x] relevant examples/test cases run
- [x] changes added to changelog
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

About the changelog, for now I only documented the breaking change in the API (the fact that `Object` now takes a `mesh_kind`). We can add another line on the changelog once the skinning system is finished :slightly_smiling_face: 

## Problems PR Solves
Continuing preparations for mesh skinning, this second PR adds a skeleton manager, and the `Skeleton` type.

Skeletons store the list of "joint deltas". This is the name I chose to refer to the transformation matrices that need to be applied to vertices, and it's not the same as the bone transformation matrices you'd usually get after running an animation system. To make this a bit more user friendly, there's two methods in `Renderer`: One sets the joint deltas directly, the other takes the global joint transforms plus the inverse bind matrices and multiplies them together. The method is not that useful once you understand mesh skinning, but I believe having it there is not a huge maintenance burden, and its docstring is good at educating users who don't know how to deal with this kind of mesh data.

Skeletons also own a range of vertices in the vertex buffer. That vertex range holds a complete duplicate of the original mesh this skeleton was created from, and will be used in the GPU skinning compute shader to modify the vertices in-place. The skeleton does not own an index buffer, instead, it can use the same index buffer as the underlying mesh.

Objects can now be created with a static mesh, or a skeleton (which has an underlying mesh). This is reflected by the change in `Object` which now has a `mesh_kind` field instead, which takes one of two variants: `Static` or `Animated`.



## Related Issues
#27