### PR TITLE
Several skinning bugfixes after #333

### DIFF
--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -78,30 +78,43 @@ impl SkeletonManager {
         handle: &SkeletonHandle,
         skeleton: Skeleton,
     ) {
-        let internal_mesh = mesh_manager.internal_data_mut(skeleton.mesh.get_raw());
+        let internal_mesh = mesh_manager.internal_data(skeleton.mesh.get_raw());
+        let num_joints = internal_mesh.num_joints;
 
-        assert_eq!(
-            internal_mesh.num_joints as usize,
-            skeleton.joint_matrices.len(),
-            "Created a skeleton with an incorrect number of joints. \
-            The mesh has {} joints, but {} joint matrices were provided.",
-            internal_mesh.num_joints as usize,
+        assert!(
+            internal_mesh.num_joints as usize <= skeleton.joint_matrices.len(),
+            "Not enough joints to create this skeleton. The mesh has {} joints, \
+             but only {} joint matrices were provided.",
+            num_joints as usize,
             skeleton.joint_matrices.len(),
         );
 
-        self.global_joint_count += skeleton.joint_matrices.len();
-        internal_mesh.skeletons.push(handle.get_raw());
+        self.global_joint_count += num_joints as usize;
 
         let mesh_range = internal_mesh.vertex_range.clone();
         let skeleton_range = mesh_manager.allocate_skeleton_mesh(device, encoder, object_manager, self, &skeleton.mesh);
+
+        // It is important that this happens after allocating the skeleton mesh.
+        // Otherwise it will try to reallocate the data for the skeleton it's
+        // trying to allocate.
+        //
+        // NOTE: Need to access internal_mesh again to avoid double borrow.
+        mesh_manager
+            .internal_data_mut(skeleton.mesh.get_raw())
+            .skeletons
+            .push(handle.get_raw());
 
         let input = GpuVertexRanges {
             skeleton_range: UVec2::new(skeleton_range.start as u32, skeleton_range.end as u32),
             mesh_range: UVec2::new(mesh_range.start as u32, mesh_range.end as u32),
         };
 
+        // Ensure there will be exactly `num_joints` matrices.
+        let mut joint_matrices = skeleton.joint_matrices;
+        joint_matrices.truncate(num_joints as usize);
+
         let internal = InternalSkeleton {
-            joint_matrices: skeleton.joint_matrices,
+            joint_matrices,
             mesh_handle: skeleton.mesh,
             skeleton_vertex_range: skeleton_range,
             ranges: input,
@@ -124,16 +137,17 @@ impl SkeletonManager {
         });
     }
 
-    pub fn set_joint_matrices(&mut self, handle: RawSkeletonHandle, joint_matrices: Vec<Mat4>) {
+    pub fn set_joint_matrices(&mut self, handle: RawSkeletonHandle, mut joint_matrices: Vec<Mat4>) {
         let skeleton = self.registry.get_mut(handle);
-        assert_eq!(
-            joint_matrices.len(),
-            skeleton.joint_matrices.len(),
-            "Call to set_joint_matrices with an incorrect number of bones. \
-            Skeleton has {} bones, input vector has {}.",
+        assert!(
+            skeleton.joint_matrices.len() <= joint_matrices.len(),
+            "Not enough joints to update this skeleton. The mesh has {} joints, \
+            but only {} joint matrices were provided.",
             skeleton.joint_matrices.len(),
             joint_matrices.len(),
         );
+        // Truncate to avoid storing any extra joint matrices
+        joint_matrices.truncate(skeleton.joint_matrices.len());
         skeleton.joint_matrices = joint_matrices;
     }
 

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -79,17 +79,17 @@ impl SkeletonManager {
         skeleton: Skeleton,
     ) {
         let internal_mesh = mesh_manager.internal_data(skeleton.mesh.get_raw());
-        let num_joints = internal_mesh.num_joints;
+        let num_joints = internal_mesh.num_joints as usize;
 
         assert!(
             internal_mesh.num_joints as usize <= skeleton.joint_matrices.len(),
             "Not enough joints to create this skeleton. The mesh has {} joints, \
              but only {} joint matrices were provided.",
-            num_joints as usize,
+            num_joints,
             skeleton.joint_matrices.len(),
         );
 
-        self.global_joint_count += num_joints as usize;
+        self.global_joint_count += num_joints;
 
         let mesh_range = internal_mesh.vertex_range.clone();
         let skeleton_range = mesh_manager.allocate_skeleton_mesh(device, encoder, object_manager, self, &skeleton.mesh);
@@ -111,7 +111,7 @@ impl SkeletonManager {
 
         // Ensure there will be exactly `num_joints` matrices.
         let mut joint_matrices = skeleton.joint_matrices;
-        joint_matrices.truncate(num_joints as usize);
+        joint_matrices.truncate(num_joints);
 
         let internal = InternalSkeleton {
             joint_matrices,

--- a/rend3/src/util/bind_merge.rs
+++ b/rend3/src/util/bind_merge.rs
@@ -1,8 +1,8 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
-    BindingResource, BindingType, Buffer, Device, Sampler, ShaderStages, TextureView,
+    BindingResource, BindingType, Buffer, BufferBinding, Device, Sampler, ShaderStages, TextureView,
 };
 
 pub struct BindGroupLayoutBuilder {
@@ -61,6 +61,15 @@ impl<'a> BindGroupBuilder<'a> {
 
     pub fn append_buffer(&mut self, buffer: &'a Buffer) -> &mut Self {
         self.append(buffer.as_entire_binding());
+        self
+    }
+
+    pub fn append_buffer_with_size(&mut self, buffer: &'a Buffer, size: u64) -> &mut Self {
+        self.append(BindingResource::Buffer(BufferBinding {
+            buffer,
+            offset: 0,
+            size: NonZeroU64::new(size),
+        }));
         self
     }
 


### PR DESCRIPTION
## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog (Already did that for #333)
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
None, that I know of

## Description
After testing my changes for #333 with a more complex scene, I uncovered several bugs in the implementation. This PR fixes:

- I was adding the skinning inputs buffer using `append_buffer`, which by default uses `as_entire_input`. This means the binding size was wrongly being set to the size of the whole buffer, which made dynamic offsets beyond `0` to fail.
- Asserting the amount of joint matrices was exactly equal to the number of joint indices in the mesh was too strict. As long as the number is greater or equal we should be fine. The size gets truncated if there are too many matrices, just because it's a cheap operation and may save a bit of bandwidth. Probably negligible though.
- Registering the skeleton handle in a mesh needs to happen after space for that skeleton has been allocated. Otherwise the code in `reallocate_buffers` will wrongly try to access the skeleton that's currently being created.
