### PR TITLE
Load animation data and rend3-gltf restructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3-textured-quad: Add example of simple 2D rendering.
 - rend3: Allow duplicating objects overriding some of their properties. @setzer22
 - rend3: Implement mesh skinning. @setzer22
+- rend3-gltf: Load gltf animation data @setzer22
 
 ### Changes
 - rend3: Instead of passing a render routine to the render function, you now add them to a rendergraph, then pass that rendergraph into the renderer.
@@ -53,6 +54,8 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3-routine: All transparency now has backface culling enabled. Use `Mesh::double_side` or `MeshBuilder::with_double_side` to re-enable double sided transparency.
 - rend3: Allow requesting device features explicitly in `rend3::create_iad`. @setzer22
 - rend3: Objects now take a `mesk_kind` allowind definition of static or animated meshes. @setzer22
+- rend3-gltf: Split return value of `load_gltf` into per-scene data and per-instance data. @setzer22
+- rend3-gltf: The `nodes` vector is now flat instead of nested. Hierarchy is represented using indices. @setzer22
 
 ### Fixes
 - rend3: Get vertex/index counts from RangeAllocator. @jamen

--- a/examples/scene-viewer/src/lib.rs
+++ b/examples/scene-viewer/src/lib.rs
@@ -10,6 +10,7 @@ use rend3::{
     Renderer, RendererMode,
 };
 use rend3_framework::{lock, AssetPath, Mutex};
+use rend3_gltf::GltfSceneInstance;
 use rend3_routine::{base::BaseRenderGraph, pbr::NormalTextureYDirection, skybox::SkyboxRoutine};
 use std::{collections::HashMap, future::Future, hash::BuildHasher, path::Path, sync::Arc, time::Duration};
 use wgpu_profiler::GpuTimerScopeResult;
@@ -63,7 +64,7 @@ async fn load_gltf(
     loader: &rend3_framework::AssetLoader,
     settings: &rend3_gltf::GltfLoadSettings,
     location: AssetPath<'_>,
-) -> Option<rend3_gltf::LoadedGltfScene> {
+) -> Option<(rend3_gltf::LoadedGltfScene, GltfSceneInstance)> {
     // profiling::scope!("loading gltf");
     let gltf_start = Instant::now();
     let is_default_scene = matches!(location, AssetPath::Internal(_));
@@ -103,7 +104,7 @@ async fn load_gltf(
 
     let gltf_elapsed = gltf_start.elapsed();
     let resources_start = Instant::now();
-    let scene = rend3_gltf::load_gltf(renderer, &gltf_data, settings, |uri| async {
+    let (scene, instance) = rend3_gltf::load_gltf(renderer, &gltf_data, settings, |uri| async {
         log::info!("Loading resource {}", uri);
         let uri = uri;
         let full_uri = parent_str.clone() + "/" + uri.as_str();
@@ -117,7 +118,7 @@ async fn load_gltf(
         gltf_elapsed,
         resources_start.elapsed()
     );
-    Some(scene)
+    Some((scene, instance))
 }
 
 fn button_pressed<Hash: BuildHasher>(map: &HashMap<u32, bool, Hash>, key: u32) -> bool {

--- a/examples/skinning/src/lib.rs
+++ b/examples/skinning/src/lib.rs
@@ -16,7 +16,7 @@ struct SkinningExample {
 /// Locates an object in the node list that corresponds to an animated mesh
 /// and returns its list of skeletons. Note that a gltf object may contain
 /// multiple primitives, and there will be one skeleton per primitive.
-pub fn find_armature<'a>(instance: &GltfSceneInstance) -> Option<rend3_gltf::Armature> {
+pub fn find_armature(instance: &GltfSceneInstance) -> Option<rend3_gltf::Armature> {
     for node in &instance.nodes {
         if let Some(ref obj) = node.inner.object {
             if let Some(ref armature) = obj.inner.armature {


### PR DESCRIPTION


## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
#27 

## Description
This PR adds the necessary modifications to rend3-gltf to allow loading and using animation data. It introduces the following changes:

- Animation data is now stored in `LoadedGltfData`'s `animations` field. The chosen schema for the `Animation` struct has been chosen to make iteration easy in an animation system, but does not deviate too far from the Gltf schema.
- The `Skin` struct now stores a list of `joints`. This is what represents the mapping between the joint indices from the mesh data to nodes in the hierarchy.
- Since both `Animation` and `Skin` now rely on storing some sort of "pointer" to the scene hierarchy, I chose to flatten the list of nodes so that those pointers could simply be integer indices.
- Another modification that was not strictly necessary but I found useful, was separating the `nodes` field from `LoadedGltfData` into a new `GltfSceneInstance` struct. This allows conveniently loading a scene once and instancing it multiple times. The original `load_gltf` function retains the old semantics where both things happen in a single call.
- An additional `topological_order` field has been added to `GltfSceneInstance`. This contains a list of node indices in topological order (i.e. child never occurs before parent). This list can be used to iterate the scene nodes in such a way that does not require any recursive functions, because data for the parent nodes is guaranteed to be computed when a child is found. An example of this can be found in `instance_loaded_scene` (previously: `load_gltf_nodes`) which computes parent transforms by iterating in topological order instead of recursing.
