### PR TITLE
Some code was using hard-coded 'PbrMaterial' instead of generic parameter 'M'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ### Fixes
 - Fixed mismatched BGLs when using a custom material with no cutout specification
+- Fixed PbrMaterial instead of generic parameter M being used in forward and depth routines. @setzer22
 
 ## v0.3.0
 

--- a/rend3-routine/src/depth.rs
+++ b/rend3-routine/src/depth.rs
@@ -157,10 +157,7 @@ impl<M: DepthRenderableMaterial> DepthRoutine<M> {
             unclipped_depth_supported,
         );
 
-        Self {
-            pipelines,
-            bg,
-        }
+        Self { pipelines, bg }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -318,7 +315,7 @@ pub struct DepthPipelines<M> {
     pub prepass_cutout_s1: Option<RenderPipeline>,
     pub prepass_opaque_s4: RenderPipeline,
     pub prepass_cutout_s4: Option<RenderPipeline>,
-    _phantom: PhantomData<M>
+    _phantom: PhantomData<M>,
 }
 impl<M: DepthRenderableMaterial> DepthPipelines<M> {
     /// If abi_bgl is Some, cutout shaders will be generated, otherwise they won't.

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -26,7 +26,6 @@ use crate::{
         GPU_VERTEX_BUFFERS,
     },
     culling,
-    pbr::PbrMaterial,
 };
 
 /// A set of pipelines for rendering a specific combination of a material.
@@ -121,7 +120,7 @@ impl<M: Material> ForwardRoutine<M> {
         if renderer.profile == RendererProfile::GpuDriven {
             bgls.push(data_core.d2_texture_manager.gpu_bgl())
         } else {
-            bgls.push(data_core.material_manager.get_bind_group_layout_cpu::<PbrMaterial>());
+            bgls.push(data_core.material_manager.get_bind_group_layout_cpu::<M>());
         }
         bgls.extend(extra_bgls);
 
@@ -223,7 +222,7 @@ impl<M: Material> ForwardRoutine<M> {
 
             match culled.inner.calls {
                 ProfileData::Cpu(ref draws) => {
-                    culling::draw_cpu_powered::<PbrMaterial>(rpass, draws, graph_data.material_manager, 2)
+                    culling::draw_cpu_powered::<M>(rpass, draws, graph_data.material_manager, 2)
                 }
                 ProfileData::Gpu(ref data) => {
                     rpass.set_bind_group(2, ready.d2_texture.bg.as_gpu(), &[]);


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
The code in `ForwardRoutine` and `DepthRoutine` sometimes ignored the generic parameter `M` and used a hard-coded `PbrMaterial` instead. This is likely a slip-up from an earlier refactor.

I feel these kinds of issues would be easier to catch in the future if we included at least one test that uses a custom material, so I will open an issue about that.