### PR TITLE
Allow customizing primitive topology in forward pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3-egui: Added the ability to create egui textures (egui::TextureId) with the wgpu backend @AlbinSjoegren
   - Added function for creating egui textures (egui::TextureId) @AlbinSjoegren
   - Added function for writing previous wgpu textures with new rgba data and exporting to egui::TextureId @AlbinSjoegren
+- rend3-routine: Added the option to set a custom primitive topology value when building a forward routine. @setzer22
 
 ### Fixes
 - Fixed mismatched BGLs when using a custom material with no cutout specification

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -63,6 +63,7 @@ impl<M: Material> ForwardRoutine<M> {
         blend: Option<BlendState>,
         use_prepass: bool,
         label: &str,
+        primitive_topology: Option<wgpu::PrimitiveTopology>,
     ) -> Self {
         profiling::scope!("PrimaryPasses::new");
 
@@ -142,6 +143,7 @@ impl<M: Material> ForwardRoutine<M> {
                 use_prepass,
                 label,
                 samples,
+                primitive_topology,
             )
         };
 
@@ -245,6 +247,7 @@ fn build_forward_pipeline_inner(
     use_prepass: bool,
     label: &str,
     samples: SampleCount,
+    primitive_topology: Option<PrimitiveTopology>,
 ) -> RenderPipeline {
     renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
         label: Some(label),
@@ -258,7 +261,7 @@ fn build_forward_pipeline_inner(
             },
         },
         primitive: PrimitiveState {
-            topology: PrimitiveTopology::TriangleList,
+            topology: primitive_topology.unwrap_or(PrimitiveTopology::TriangleList),
             strip_index_format: None,
             front_face: match renderer.handedness {
                 Handedness::Left => FrontFace::Cw,

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -62,8 +62,8 @@ impl<M: Material> ForwardRoutine<M> {
 
         blend: Option<BlendState>,
         use_prepass: bool,
+        primitive_topology: wgpu::PrimitiveTopology,
         label: &str,
-        primitive_topology: Option<wgpu::PrimitiveTopology>,
     ) -> Self {
         profiling::scope!("PrimaryPasses::new");
 
@@ -141,9 +141,9 @@ impl<M: Material> ForwardRoutine<M> {
                 forward_pass_frag,
                 blend,
                 use_prepass,
+                primitive_topology,
                 label,
                 samples,
-                primitive_topology,
             )
         };
 
@@ -245,9 +245,9 @@ fn build_forward_pipeline_inner(
     forward_pass_frag: &wgpu::ShaderModule,
     blend: Option<BlendState>,
     use_prepass: bool,
+    primitive_topology: PrimitiveTopology,
     label: &str,
     samples: SampleCount,
-    primitive_topology: Option<PrimitiveTopology>,
 ) -> RenderPipeline {
     renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
         label: Some(label),
@@ -261,7 +261,7 @@ fn build_forward_pipeline_inner(
             },
         },
         primitive: PrimitiveState {
-            topology: primitive_topology.unwrap_or(PrimitiveTopology::TriangleList),
+            topology: primitive_topology,
             strip_index_format: None,
             front_face: match renderer.handedness {
                 Handedness::Left => FrontFace::Cw,

--- a/rend3-routine/src/pbr/routine.rs
+++ b/rend3-routine/src/pbr/routine.rs
@@ -52,12 +52,12 @@ impl PbrRoutine {
                     TransparencyType::Blend => Some(BlendState::ALPHA_BLENDING),
                 },
                 !matches!(transparency, TransparencyType::Blend),
+                wgpu::PrimitiveTopology::TriangleList,
                 match transparency {
                     TransparencyType::Opaque => "opaque pass",
                     TransparencyType::Cutout => "cutout pass",
                     TransparencyType::Blend => "blend forward pass",
                 },
-                None,
             )
         };
 

--- a/rend3-routine/src/pbr/routine.rs
+++ b/rend3-routine/src/pbr/routine.rs
@@ -57,6 +57,7 @@ impl PbrRoutine {
                     TransparencyType::Cutout => "cutout pass",
                     TransparencyType::Blend => "blend forward pass",
                 },
+                None,
             )
         };
 


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
None that I'm aware

## Description
Here's a very minor change allowing customization of the PrimitiveTopology when building a forward pipeline. This allows reusing the forward pipeline for more things, like a wireframe renderer.
