### PR TITLE
Removed dynamic data in profiling scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Fixed mismatched BGLs when using a custom material with no cutout specification
 - Fixed PbrMaterial instead of generic parameter M being used in forward and depth routines. @setzer22
 - Fixes loading of gltf with embedded base64 binary data.
+- Fixed building with `profiling/profile-with-tracing`. @SparkyPotato
 
 ## v0.3.0
 

--- a/rend3/src/graph/graph.rs
+++ b/rend3/src/graph/graph.rs
@@ -353,7 +353,7 @@ impl<'node> RenderGraph<'node> {
                     None => RenderGraphEncoderOrPassInner::Encoder(unsafe { &mut *encoder_cell.get() }),
                 };
 
-                profiling::scope!(&node.label);
+                profiling::scope!("Execute Node");
 
                 data_core
                     .profiler

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    format_sso,
     graph::{GraphTextureStore, ReadyData},
     instruction::{InstructionKind, InstructionStreamPair},
     managers::{
@@ -277,8 +276,7 @@ impl Renderer {
         for new_mip in 0..mip_level_count {
             let old_mip = new_mip + texture.start_mip;
 
-            let _label = format_sso!("mip {} to {}", old_mip, new_mip);
-            profiling::scope!(&_label);
+            profiling::scope!("mip level generation");
 
             encoder.copy_texture_to_texture(
                 ImageCopyTexture {

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -430,7 +430,7 @@ pub async fn create_iad(
     let mut valid_adapters = FastHashMap::<Backend, ArrayVec<PotentialAdapter<Adapter>, 4>>::default();
 
     for backend in &default_backend_order {
-        profiling::scope!("enumerating backend", &format_sso!("{:?}", backend));
+        profiling::scope!("enumerating backend");
         #[cfg(not(target_arch = "wasm32"))]
         let adapters = instance.enumerate_adapters(Backends::from(*backend));
         #[cfg(target_arch = "wasm32")]

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -106,7 +106,7 @@ impl MipmapGenerator {
         sm: &ShaderModule,
     ) -> RenderPipeline {
         let label = format_sso!("mipmap pipeline {:?}", format);
-        profiling::scope!(&label);
+        profiling::scope!("mipmap pipeline");
         device.create_render_pipeline(&RenderPipelineDescriptor {
             label: Some(&label),
             layout: Some(pll),
@@ -180,9 +180,8 @@ impl MipmapGenerator {
             let dst_view = &view_window[1];
 
             let src_label = format_sso!("Mipmap level {}", idx);
-            let _dst_label = format_sso!("Mipmap level {}", idx + 1);
 
-            profiling::scope!(&_dst_label);
+            profiling::scope!("mip level generation");
             // profiler.lock().begin_scope(&dst_label, encoder, device);
 
             let bg = BindGroupBuilder::new().append_texture_view(src_view).build(

--- a/rend3/src/util/registry/erased.rs
+++ b/rend3/src/util/registry/erased.rs
@@ -247,10 +247,7 @@ fn remove_all_dead<T: Send + Sync + 'static, Metadata>(
 ) {
     let mut vec = vec_any.downcast_mut::<T>().unwrap();
 
-    profiling::scope!(&format!(
-        "ArchitypicalRegistry::<{}>::remove_all_dead",
-        std::any::type_name::<T>()
-    ));
+    profiling::scope!("ArchitypicalRegistry::remove_all_dead");
 
     assert_eq!(vec.len(), non_erased.len());
     for idx in (0..vec.len()).rev() {


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
Fixes #393

## Description
All `profiling::scope!` names are now statically known, and `rend3` compiles with profiling features enabled
