### PR TITLE
Add support for egui 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3-routine: Added the option to set a custom primitive topology value when building a forward routine. @setzer22
 - rend3-routine: Added a resolution field to the per-frame uniforms. @setzer22
 - rend3-routine: Added add_clear_to_graph to make clears explicit and add `clear_color` argument to base rendergraph.
+- rend3-egui: Update to egui 0.18 @setzer22
 
 ### Fixes
 - Fixed mismatched BGLs when using a custom material with no cutout specification

--- a/examples/egui/Cargo.toml
+++ b/examples/egui/Cargo.toml
@@ -13,11 +13,9 @@ path = "src/main.rs"
 
 [dependencies]
 # The egui immediate mode gui library
-egui = "0.17.0"
-# Backend-agnostic interface for writing apps using egui
-epi = "0.17.0"
+egui = { git = "https://github.com/emilk/egui", rev = "5d15e3d367632289"}
 # Winit integration with egui
-egui_winit_platform = "0.14.0"
+egui-winit = { git = "https://github.com/emilk/egui", rev = "5d15e3d367632289"}
 # logging
 env_logger = { version = "0.9", default-features = false, features = ["termcolor", "atty"] }
 # Linear algebra library

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -12,9 +12,8 @@ categories = ["game-development", "graphics", "rendering", "rendering::engine", 
 rust-version = "1.57"
 
 [dependencies]
-egui = "0.17.0"
-egui_wgpu_backend = "0.17.0"
-epi = "0.17.0"
+egui = { git = "https://github.com/emilk/egui", rev = "5d15e3d367632289"}
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "5d15e3d367632289"}
 glam = "0.20.0"
 rend3 = { version = "^0.3.0", path = "../rend3" }
 wgpu = "0.12"

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -271,7 +271,7 @@ pub async fn filesystem_io_func(parent_directory: impl AsRef<Path>, uri: &str) -
         return Ok(data);
     }
 
-    let path_resolved = parent_directory.as_ref().join(&*uri);
+    let path_resolved = parent_directory.as_ref().join(&uri);
     let display = path_resolved.as_os_str().to_string_lossy();
     // profiling::scope!("loading file", &display);
     log::info!("loading file '{}' from disk", &display);

--- a/rend3-routine/src/pbr/material.rs
+++ b/rend3-routine/src/pbr/material.rs
@@ -420,7 +420,7 @@ impl Default for SampleType {
 
 /// The type of transparency in a material.
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TransparencyType {
     /// Alpha is completely ignored.
     Opaque,

--- a/rend3/src/graph/mod.rs
+++ b/rend3/src/graph/mod.rs
@@ -123,20 +123,20 @@ enum GraphResource {
 }
 
 /// Handle to a graph-stored render target.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct RenderTargetHandle {
     // Must only be OutputTexture or Texture
     resource: GraphResource,
 }
 
 /// Handle to a single shadow map.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ShadowTargetHandle {
     idx: usize,
 }
 
 /// Handle to the entire shadow atlas.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ShadowArrayHandle;
 
 /// Targets that make up a renderpass.

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -335,7 +335,7 @@ impl<T> PotentialAdapter<T> {
 }
 
 /// Set of common GPU vendors.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Vendor {
     Nv,
     Amd,


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

I updated egui to 0.18 and updated the code to use the new integrations. Everything seems to run smoothly.

But unfortunately, this PR is blocked because the new winit/wgpu integrations (now under the main egui repo, and released in lockstep with egui itself) removed the `egui_texture_from_wgpu_texture` which was used in rend3-egui. The old `egui_wgpu_backend` and `egui_winit_platform` now seem to be unmaitained and stuck on egui 0.17, so we can't use those either.

The function is back on egui master, as of https://github.com/emilk/egui/commit/5d15e3d367632289347559c430c8903b54d71090, so I was able to implement this update using git dependencies. This is obviously not useful to users wanting to stay on the crates.io version of egui, and would lock rend3 out of a crates.io release. Regardless, the changes were useful to me so I thought I'd submit them so that they can be used as a base once egui 0.19 releases.
