### PR TITLE
Fix remove_all_dead callback in skeleton manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Fixed PbrMaterial instead of generic parameter M being used in forward and depth routines. @setzer22
 - Fixes loading of gltf with embedded base64 binary data.
 - Fixed building with `profiling/profile-with-tracing`. @SparkyPotato
+- Fixed panic when a mesh object with a skeleton was despawned. @setzer22
 
 ## v0.3.0
 

--- a/rend3-anim/src/lib.rs
+++ b/rend3-anim/src/lib.rs
@@ -15,11 +15,10 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use rend3::types::Handedness;
 use rend3::{
     types::{
         glam::{Mat4, Quat, Vec3},
-        SkeletonHandle,
+        Handedness, SkeletonHandle,
     },
     util::typedefs::{FastHashMap, FastHashSet},
     Renderer,

--- a/rend3/src/managers/directional.rs
+++ b/rend3/src/managers/directional.rs
@@ -155,7 +155,7 @@ impl DirectionalLightManager {
     pub fn ready(&mut self, device: &Device, queue: &Queue, user_camera: &CameraManager) -> Vec<CameraManager> {
         profiling::scope!("Directional Light Ready");
 
-        self.registry.remove_all_dead(|_, _, _| ());
+        self.registry.remove_all_dead(|_, _, _, _| ());
 
         let registered_count: usize = self.registry.values().len();
         let recreate_view = registered_count != self.coords.len() && registered_count != 0;

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -349,7 +349,7 @@ impl MeshManager {
 
         let vertex_alloc = &mut self.vertex_alloc;
         let index_alloc = &mut self.index_alloc;
-        self.registry.remove_all_dead(|_, _, mesh| {
+        self.registry.remove_all_dead(|_, _, _, mesh| {
             if mesh.vertex_range.is_empty() {
                 return;
             }

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -123,7 +123,7 @@ impl SkeletonManager {
 
     pub fn ready(&mut self, mesh_manager: &mut MeshManager) {
         profiling::scope!("Skeleton Manager Ready");
-        self.registry.remove_all_dead(|_, handle_idx, skeleton| {
+        self.registry.remove_all_dead(|_, _, handle_idx, skeleton| {
             self.global_joint_count -= skeleton.joint_matrices.len();
 
             // Clean back references in the mesh data

--- a/rend3/src/managers/texture.rs
+++ b/rend3/src/managers/texture.rs
@@ -103,7 +103,7 @@ impl TextureManager {
         profiling::scope!("TextureManager::ready");
 
         let views = &mut self.views;
-        self.registry.remove_all_dead(|_, index, _| {
+        self.registry.remove_all_dead(|_, index, _, _| {
             // Do the same swap remove move as the registry did
             views.swap_remove(index);
         });

--- a/rend3/src/util/registry/basic.rs
+++ b/rend3/src/util/registry/basic.rs
@@ -36,13 +36,24 @@ impl<T, HandleType> ResourceRegistry<T, HandleType> {
         );
     }
 
-    pub fn remove_all_dead(&mut self, mut func: impl FnMut(&mut Self, usize, T)) {
+    /// The provided `func` will be called for each removed value with the
+    /// following parameters:
+    ///
+    /// - `registry`: A reference to this resource registry
+    /// - `idx`: The position of the removed element inside the inner mapping.
+    ///    Used when parallel structures are maintained and need to be adjusted
+    ///    accordingly (e.g. with `swap_remove`)
+    /// - `handle_idx`: The index inside the raw handle of the resource that is
+    ///    being removed.
+    ///  - `value`: The removed value.
+    pub fn remove_all_dead(&mut self, mut func: impl FnMut(&mut Self, usize, usize, T)) {
         profiling::scope!("ResourceRegistry::remove_all_dead");
         for idx in (0..self.mapping.len()).rev() {
-            let element = self.mapping.get_index(idx).unwrap().1;
-            if element.refcount.strong_count() == 0 {
+            let element = self.mapping.get_index(idx).unwrap();
+            let handle_idx = *element.0;
+            if element.1.refcount.strong_count() == 0 {
                 let (_, value) = self.mapping.swap_remove_index(idx).unwrap();
-                func(self, idx, value.data)
+                func(self, idx, handle_idx, value.data)
             }
         }
     }


### PR DESCRIPTION
Here's the patch fixing #421, as we discussed :smile:  For the time being, I simply added an additional parameter to the callback in `remove_all_dead`. I also added documentation explaining what each parameter is. 

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

Fixes #421 

## Description
