### PR TITLE
Enable depth write in forward pass when not using prepass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Fixes loading of gltf with embedded base64 binary data.
 - Fixed building with `profiling/profile-with-tracing`. @SparkyPotato
 - Fixed panic when a mesh object with a skeleton was despawned. @setzer22
+- Fixed forward pass not writing to depth when no depth prepass was used. @IsseW
 
 ## v0.3.0
 

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -262,7 +262,7 @@ fn build_forward_pipeline_inner(
         },
         depth_stencil: Some(DepthStencilState {
             format: TextureFormat::Depth32Float,
-            depth_write_enabled: blend.is_none() && use_prepass,
+            depth_write_enabled: blend.is_none() && !use_prepass,
             depth_compare: match use_prepass {
                 true => CompareFunction::Equal,
                 false => CompareFunction::GreaterEqual,


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
Fixes a logical error which makes forward routine write to depth when there is a prepass and not write to depth when there isn't a prepass. 