### PR TITLE
Draft: Add render target inputs as a parameter to add_forward_to_graph

### DIFF
--- a/rend3-routine/src/base.rs
+++ b/rend3-routine/src/base.rs
@@ -370,6 +370,7 @@ impl BaseRenderGraphIntermediateState {
                 self.forward_uniform_bg,
                 trans.cull,
                 None,
+                None,
                 &format_sso!("PBR Forward {:?}", trans.ty),
                 samples,
                 self.color,

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -11,7 +11,8 @@ use rend3::{
         RenderTargetHandle,
     },
     types::{Handedness, Material, SampleCount},
-    ProfileData, Renderer, RendererDataCore, RendererProfile, ShaderConfig, ShaderPreProcessor, util::bind_merge::BindGroupBuilder,
+    util::bind_merge::BindGroupBuilder,
+    ProfileData, Renderer, RendererDataCore, RendererProfile, ShaderConfig, ShaderPreProcessor,
 };
 use wgpu::{
     BindGroup, BindGroupLayout, BlendState, Color, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState,
@@ -229,7 +230,8 @@ impl<M: Material> ForwardRoutine<M> {
                     builder.append_texture_view(view);
                 }
 
-                let input_render_targets_bg = temps.add(builder.build(&renderer.device, Some("input render targets"), bind_group));
+                let input_render_targets_bg =
+                    temps.add(builder.build(&renderer.device, Some("input render targets"), bind_group));
                 rpass.set_bind_group(group, input_render_targets_bg, &[]);
             }
 

--- a/rend3-routine/src/pbr/routine.rs
+++ b/rend3-routine/src/pbr/routine.rs
@@ -54,6 +54,7 @@ impl PbrRoutine {
                 None,
                 None,
                 &[],
+                None,
                 match transparency {
                     TransparencyType::Opaque | TransparencyType::Cutout => None,
                     TransparencyType::Blend => Some(BlendState::ALPHA_BLENDING),


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

## Description

Adds render targets as a parameter to `add_forward_graph`, so that you don't have to create bind groups when you want to bind a render target as a texture view.

This could potentially be done a few other ways, this is mostly looking for comments as to if it would be of interest to have something like this. 