### PR TITLE
Switch PresentMode of cube-no-framework example to Fifo

### DIFF
--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
         &iad.device,
         preferred_format,
         glam::UVec2::new(window_size.width, window_size.height),
-        rend3::types::PresentMode::Mailbox,
+        rend3::types::PresentMode::Fifo,
     );
 
     // Make us a renderer.


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
#437

## Description
When wgpu was updated to 0.14, the call to `configure_surface` in rend3_framework was changed from `PresentMode::Mailbox` to `PresentMode::Fifo`, since mailbox no longer gracefully degrades to Fifo. This change was not made for the `cube-no-framework` example which now panics on older GPUs / drivers that don't support mailbox.