### PR TITLE
Set PresentMode to Fifo on surface resize for no-cube-framework example

### DIFF
--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -188,7 +188,7 @@ fn main() {
                 &renderer.device,
                 preferred_format,
                 glam::UVec2::new(resolution.x, resolution.y),
-                rend3::types::PresentMode::Mailbox,
+                rend3::types::PresentMode::Fifo,
             );
             // Tell the renderer about the new aspect ratio.
             renderer.set_aspect_ratio(resolution.x as f32 / resolution.y as f32);


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

https://github.com/BVE-Reborn/rend3/issues/437

## Description

https://github.com/BVE-Reborn/rend3/pull/439 changed the no-cube-framework present mode to `Fifo` but did not change this for when the surface is resized.