### PR TITLE
Separate ready into `swap_instruction_buffers` and `evaluate_instructions`

### DIFF
--- a/examples/animation/src/lib.rs
+++ b/examples/animation/src/lib.rs
@@ -150,8 +150,11 @@ impl rend3_framework::App for AnimationExample {
             rend3_framework::Event::RedrawRequested(_) => {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -166,7 +169,7 @@ impl rend3_framework::App for AnimationExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -178,7 +181,7 @@ impl rend3_framework::App for AnimationExample {
                 );
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 // Present the frame
                 frame.present();

--- a/examples/cube-no-framework/src/main.rs
+++ b/examples/cube-no-framework/src/main.rs
@@ -198,8 +198,11 @@ fn main() {
         winit::event::Event::MainEventsCleared => {
             // Get a frame
             let frame = surface.get_current_texture().unwrap();
-            // Ready up the renderer
-            let (cmd_bufs, ready) = renderer.ready();
+
+            // Swap the instruction buffers so that our frame's changes can be processed.
+            renderer.swap_instruction_buffers();
+            // Evaluate our frame's world-change instructions
+            let mut eval_output = renderer.evaluate_instructions();
 
             // Build a rendergraph
             let mut graph = rend3::graph::RenderGraph::new();
@@ -210,7 +213,7 @@ fn main() {
             // Add the default rendergraph without a skybox
             base_rendergraph.add_to_graph(
                 &mut graph,
-                &ready,
+                &eval_output,
                 &pbr_routine,
                 None,
                 &tonemapping_routine,
@@ -222,7 +225,7 @@ fn main() {
             );
 
             // Dispatch a render using the built up rendergraph!
-            graph.execute(&renderer, cmd_bufs, &ready);
+            graph.execute(&renderer, &mut eval_output);
 
             // Present the frame
             frame.present();

--- a/examples/cube/src/lib.rs
+++ b/examples/cube/src/lib.rs
@@ -153,8 +153,11 @@ impl rend3_framework::App for CubeExample {
             rend3_framework::Event::RedrawRequested(_) => {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -169,7 +172,7 @@ impl rend3_framework::App for CubeExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -181,7 +184,7 @@ impl rend3_framework::App for CubeExample {
                 );
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 // Present the frame
                 frame.present();

--- a/examples/egui/src/main.rs
+++ b/examples/egui/src/main.rs
@@ -196,8 +196,10 @@ impl rend3_framework::App for EguiExample {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
 
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -212,7 +214,7 @@ impl rend3_framework::App for EguiExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -227,7 +229,7 @@ impl rend3_framework::App for EguiExample {
                 data.egui_routine.add_to_graph(&mut graph, input, frame_handle);
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 // Present the frame
                 frame.present();

--- a/examples/imgui/src/main.rs
+++ b/examples/imgui/src/main.rs
@@ -159,8 +159,10 @@ impl rend3_framework::App for ImguiExample {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
 
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -175,7 +177,7 @@ impl rend3_framework::App for ImguiExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -191,7 +193,7 @@ impl rend3_framework::App for ImguiExample {
                     .add_to_graph(&mut graph, data.imgui.render(), frame_handle);
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 control_flow(winit::event_loop::ControlFlow::Poll);
             }

--- a/examples/skinning/src/lib.rs
+++ b/examples/skinning/src/lib.rs
@@ -146,8 +146,10 @@ impl rend3_framework::App for SkinningExample {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
 
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -161,7 +163,7 @@ impl rend3_framework::App for SkinningExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -173,7 +175,7 @@ impl rend3_framework::App for SkinningExample {
                 );
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 frame.present();
             }

--- a/examples/static-gltf/src/main.rs
+++ b/examples/static-gltf/src/main.rs
@@ -135,8 +135,11 @@ impl rend3_framework::App for GltfExample {
             rend3_framework::Event::RedrawRequested(..) => {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -151,7 +154,7 @@ impl rend3_framework::App for GltfExample {
                 // Add the default rendergraph without a skybox
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -162,7 +165,7 @@ impl rend3_framework::App for GltfExample {
                     glam::Vec4::new(0.10, 0.05, 0.10, 1.0), // Nice scene-referred purple
                 );
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 // Present the frame
                 frame.present();

--- a/examples/textured-quad/src/main.rs
+++ b/examples/textured-quad/src/main.rs
@@ -161,8 +161,10 @@ impl rend3_framework::App for TexturedQuadExample {
                 // Get a frame
                 let frame = surface.unwrap().get_current_texture().unwrap();
 
-                // Ready up the renderer
-                let (cmd_bufs, ready) = renderer.ready();
+                // Swap the instruction buffers so that our frame's changes can be processed.
+                renderer.swap_instruction_buffers();
+                // Evaluate our frame's world-change instructions
+                let mut eval_output = renderer.evaluate_instructions();
 
                 // Lock the routines
                 let pbr_routine = rend3_framework::lock(&routines.pbr);
@@ -177,7 +179,7 @@ impl rend3_framework::App for TexturedQuadExample {
                 // Add the default rendergraph
                 base_rendergraph.add_to_graph(
                     &mut graph,
-                    &ready,
+                    &eval_output,
                     &pbr_routine,
                     None,
                     &tonemapping_routine,
@@ -189,7 +191,7 @@ impl rend3_framework::App for TexturedQuadExample {
                 );
 
                 // Dispatch a render using the built up rendergraph!
-                graph.execute(renderer, cmd_bufs, &ready);
+                graph.execute(renderer, &mut eval_output);
 
                 // Present the frame
                 frame.present();

--- a/rend3-routine/src/culling/culler.rs
+++ b/rend3-routine/src/culling/culler.rs
@@ -252,7 +252,7 @@ impl GpuCuller {
             entries: &[
                 BindGroupEntry {
                     binding: 0,
-                    resource: ctx.ready.mesh_buffer.as_entire_binding(),
+                    resource: ctx.eval_output.mesh_buffer.as_entire_binding(),
                 },
                 BindGroupEntry {
                     binding: 1,
@@ -329,7 +329,7 @@ impl GpuCuller {
 
         node.build(move |mut ctx| {
             let camera_manager = match camera {
-                Some(i) => &ctx.ready.shadows[i].camera,
+                Some(i) => &ctx.eval_output.shadows[i].camera,
                 None => &ctx.data_core.camera_manager,
             };
 

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -179,7 +179,7 @@ impl<M: Material> ForwardRoutine<M> {
                         &culled.buffers.object_reference,
                         culling::ShaderBatchData::SHADER_SIZE.get(),
                     )
-                    .append_buffer(&ctx.ready.mesh_buffer)
+                    .append_buffer(&ctx.eval_output.mesh_buffer)
                     .append_buffer(ctx.data_core.material_manager.archetype_view::<M>().buffer())
                     .build(&ctx.renderer.device, Some("Per-Material BG"), &args.per_material.bgl),
             );
@@ -197,7 +197,7 @@ impl<M: Material> ForwardRoutine<M> {
                     rpass.set_bind_group((idx + 3) as _, bg, &[])
                 }
             }
-            if let ProfileData::Gpu(ref bg) = ctx.ready.d2_texture.bg {
+            if let ProfileData::Gpu(ref bg) = ctx.eval_output.d2_texture.bg {
                 rpass.set_bind_group(2, bg, &[]);
             }
 

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -185,7 +185,7 @@ impl GpuSkinner {
 
     pub fn execute_pass(&self, ctx: &NodeExecutionContext, encoder: &mut CommandEncoder, buffers: &PreSkinningBuffers) {
         let bg = BindGroupBuilder::new()
-            .append_buffer(&ctx.ready.mesh_buffer)
+            .append_buffer(&ctx.eval_output.mesh_buffer)
             .append_buffer_with_size(&buffers.gpu_skinning_inputs, GpuSkinningInput::SHADER_SIZE.get())
             .append_buffer(&buffers.joint_matrices)
             .build(&ctx.renderer.device, Some("GPU skinning inputs"), &self.bgl);

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -65,8 +65,8 @@ impl SkyboxRoutine {
         self.current_skybox.bg = None;
     }
 
-    /// Update data if the background has changed since last frame.
-    pub fn ready(&mut self, renderer: &Renderer) {
+    /// Evaluate any changes that have happened to the skybox routine.
+    pub fn evaluate(&mut self, renderer: &Renderer) {
         let data_core = renderer.data_core.lock();
         let d2c_texture_manager = &data_core.d2c_texture_manager;
 

--- a/rend3/src/graph/node.rs
+++ b/rend3/src/graph/node.rs
@@ -2,8 +2,8 @@ use std::{cell::RefCell, marker::PhantomData};
 
 use crate::{
     graph::{
-        DataHandle, GraphSubResource, ReadyData, RenderGraph, RenderGraphDataStore, RenderGraphEncoderOrPass,
-        RenderPassHandle, RenderPassTargets, RenderTargetHandle, RpassTemporaryPool,
+        DataHandle, GraphSubResource, InstructionEvaluationOutput, RenderGraph, RenderGraphDataStore,
+        RenderGraphEncoderOrPass, RenderPassHandle, RenderPassTargets, RenderTargetHandle, RpassTemporaryPool,
     },
     util::typedefs::SsoString,
     Renderer, RendererDataCore,
@@ -25,8 +25,8 @@ pub struct NodeExecutionContext<'a, 'pass, 'node: 'pass> {
     /// Storage for any temporary data that needs to live as long
     /// as the renderpass.
     pub temps: &'pass RpassTemporaryPool<'pass>,
-    /// The result of calling ready on the renderer.
-    pub ready: &'pass ReadyData,
+    /// The result of calling evaluate_instructions on the renderer.
+    pub eval_output: &'pass InstructionEvaluationOutput,
     /// Store to get data from
     pub graph_data: RenderGraphDataStore<'pass>,
     pub _phantom: PhantomData<&'node ()>,

--- a/rend3/src/managers/directional.rs
+++ b/rend3/src/managers/directional.rs
@@ -100,8 +100,8 @@ impl DirectionalLightManager {
         self.data[handle.idx].take().unwrap();
     }
 
-    pub fn ready(&mut self, renderer: &Renderer, user_camera: &CameraManager) -> (UVec2, Vec<ShadowDesc>) {
-        profiling::scope!("Directional Light Ready");
+    pub fn evaluate(&mut self, renderer: &Renderer, user_camera: &CameraManager) -> (UVec2, Vec<ShadowDesc>) {
+        profiling::scope!("DirectionalLightManager::evaluate");
 
         let shadow_maps: Vec<_> = self
             .data

--- a/rend3/src/managers/material.rs
+++ b/rend3/src/managers/material.rs
@@ -216,7 +216,7 @@ impl MaterialManager {
         }
     }
 
-    pub fn ready(
+    pub fn evaluate(
         &mut self,
         device: &Device,
         encoder: &mut CommandEncoder,
@@ -224,7 +224,7 @@ impl MaterialManager {
         profile: RendererProfile,
         texture_manager: &TextureManager<crate::types::Texture2DTag>,
     ) {
-        profiling::scope!("Material Ready");
+        profiling::scope!("MaterialManager::evaluate");
 
         for archetype in self.archetypes.values_mut() {
             match profile {

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -187,7 +187,7 @@ impl MeshManager {
         allocator_guard.free_range(mesh.index_range);
     }
 
-    pub fn ready(&self) -> Arc<Buffer> {
+    pub fn evaluate(&self) -> Arc<Buffer> {
         self.buffer.read().clone()
     }
 

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -81,7 +81,7 @@ struct ObjectArchetype {
     set_object_transform: fn(&mut VecAny, &mut FreelistDerivedBuffer, usize, Mat4),
     duplicate_object: fn(&VecAny, usize, ObjectChange) -> Object,
     remove: fn(&mut VecAny, usize),
-    ready: fn(&mut ObjectArchetype, &Device, &mut CommandEncoder, &ScatterCopy),
+    evaluate: fn(&mut ObjectArchetype, &Device, &mut CommandEncoder, &ScatterCopy),
 }
 
 /// Manages objects. That's it. ¯\\\_(ツ)\_/¯
@@ -108,7 +108,7 @@ impl ObjectManager {
             set_object_transform: set_object_transform::<M>,
             duplicate_object: duplicate_object::<M>,
             remove: remove::<M>,
-            ready: ready::<M>,
+            evaluate: evaluate::<M>,
         })
     }
 
@@ -165,9 +165,9 @@ impl ObjectManager {
         archetype.object_count -= 1;
     }
 
-    pub fn ready(&mut self, device: &Device, encoder: &mut CommandEncoder, scatter: &ScatterCopy) {
+    pub fn evaluate(&mut self, device: &Device, encoder: &mut CommandEncoder, scatter: &ScatterCopy) {
         for archetype in self.archetype.values_mut() {
-            (archetype.ready)(archetype, device, encoder, scatter);
+            (archetype.evaluate)(archetype, device, encoder, scatter);
         }
     }
 
@@ -340,7 +340,7 @@ fn remove<M: Material>(data: &mut VecAny, idx: usize) {
     data_vec[idx] = None;
 }
 
-fn ready<M: Material>(
+fn evaluate<M: Material>(
     archetype: &mut ObjectArchetype,
     device: &Device,
     encoder: &mut CommandEncoder,

--- a/rend3/src/managers/texture.rs
+++ b/rend3/src/managers/texture.rs
@@ -252,8 +252,8 @@ impl<T: 'static> TextureManager<T> {
         self.data[handle.idx] = None;
     }
 
-    pub fn ready(&mut self, device: &Device) -> TextureManagerReadyOutput {
-        profiling::scope!("TextureManager::ready");
+    pub fn evaluate(&mut self, device: &Device) -> TextureManagerEvaluateOutput {
+        profiling::scope!("TextureManager::evaluate");
 
         if let ProfileData::Gpu(group_dirty) = self.group_dirty {
             profiling::scope!("Update GPU Texture Arrays");
@@ -269,11 +269,11 @@ impl<T: 'static> TextureManager<T> {
                 *self.group_dirty.as_gpu_mut() = false;
             }
 
-            TextureManagerReadyOutput {
+            TextureManagerEvaluateOutput {
                 bg: self.group.as_ref().map(|_| (), Arc::clone),
             }
         } else {
-            TextureManagerReadyOutput {
+            TextureManagerEvaluateOutput {
                 bg: ProfileData::Cpu(()),
             }
         }
@@ -300,9 +300,9 @@ impl<T: 'static> TextureManager<T> {
     }
 }
 
-/// Output of readying up a [`TextureManager`].
+/// Output of calling [`TextureManager::evaluate`].
 #[derive(Clone)]
-pub struct TextureManagerReadyOutput {
+pub struct TextureManagerEvaluateOutput {
     pub bg: ProfileData<(), Arc<BindGroup>>,
 }
 


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Closes #392

Separates the swapping of buffers and evaluation of instructions to allow more aggressive parallelism.

Also renames various types to be more descriptive.