### PR TITLE
Allow dispatch batching beyond the draw call level

### DIFF
--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -204,8 +204,7 @@ impl<M: Material> ForwardRoutine<M> {
             let Some(range) = culled.material_key_ranges.get(&self.material_key) else {
                 return;
             };
-            for (idx, call) in culled.draw_calls[range.clone()].iter().enumerate() {
-                let idx = idx + range.start;
+            for call in &culled.draw_calls[range.clone()] {
                 let call: &DrawCall = call;
 
                 if ctx.renderer.profile.is_cpu_driven() {
@@ -218,7 +217,7 @@ impl<M: Material> ForwardRoutine<M> {
                 rpass.set_bind_group(
                     1,
                     per_material_bg,
-                    &[idx as u32 * culling::ShaderBatchData::SHADER_SIZE.get() as u32],
+                    &[call.batch_index * culling::ShaderBatchData::SHADER_SIZE.get() as u32],
                 );
                 rpass.draw_indexed(call.index_range.clone(), 0, args.data..args.data + 1);
             }


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

This changes the dispatch algorithm to allow culling across draw call lines within the same dispatch. This prevents issues with tiny dispatches and partially mitigates the need for parallel compute passes.