### PR TITLE
Expose &Texture to users via RenderGraphDataStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - rend3-routine: Added the option to set a custom primitive topology value when building a forward routine. @setzer22
 - rend3-routine: Added a resolution field to the per-frame uniforms. @setzer22
 - rend3-routine: Added add_clear_to_graph to make clears explicit and add `clear_color` argument to base rendergraph.
+- rend3: Added a way to obtain a &Texture, not just a &TextureView when inside a node. @setzer22
 
 ### Changes
 - rend3: Update to wgpu 0.13, naga 0.9 @garyttierney

--- a/rend3/src/graph/graph.rs
+++ b/rend3/src/graph/graph.rs
@@ -339,12 +339,13 @@ impl<'node> RenderGraph<'node> {
             match *sub_resource {
                 GraphSubResource::Texture(region) => {
                     if let Entry::Vacant(vacant) = active_views.entry(region) {
-                        let view = active_textures[&region.idx].create_view(&TextureViewDescriptor {
+                        let texture = &active_textures[&region.idx];
+                        let view = texture.create_view(&TextureViewDescriptor {
                             base_array_layer: region.layer_start,
                             array_layer_count: Some(NonZeroU32::new(region.layer_end - region.layer_start).unwrap()),
                             ..TextureViewDescriptor::default()
                         });
-                        vacant.insert(view);
+                        vacant.insert((view, Arc::clone(texture)));
                     }
                 }
                 GraphSubResource::ImportedTexture(region) => {
@@ -539,13 +540,13 @@ impl<'node> RenderGraph<'node> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn create_rpass_from_desc<'rpass>(
+    fn create_rpass_from_desc<'rpass, A>(
         desc: &RenderPassTargets,
         encoder: &'rpass mut CommandEncoder,
         node_idx: usize,
         pass_end_idx: usize,
         resource_spans: &'rpass FastHashMap<GraphResource, ResourceSpan>,
-        active_views: &'rpass FastHashMap<TextureRegion, TextureView>,
+        active_views: &'rpass FastHashMap<TextureRegion, (TextureView, A)>,
         active_imported_views: &'rpass FastHashMap<TextureRegion, TextureView>,
     ) -> RenderPass<'rpass> {
         let color_attachments: Vec<_> = desc
@@ -567,14 +568,14 @@ impl<'node> RenderGraph<'node> {
                 RenderPassColorAttachment {
                     view: match target.color.handle.resource {
                         GraphSubResource::ImportedTexture(region) => &active_imported_views[&region],
-                        GraphSubResource::Texture(region) => &active_views[&region],
+                        GraphSubResource::Texture(region) => &active_views[&region].0,
                         _ => {
                             panic!("internal rendergraph error: using a non-texture as a renderpass attachment")
                         }
                     },
                     resolve_target: target.resolve.as_ref().map(|dep| match dep.handle.resource {
                         GraphSubResource::ImportedTexture(region) => &active_imported_views[&region],
-                        GraphSubResource::Texture(region) => &active_views[&region],
+                        GraphSubResource::Texture(region) => &active_views[&region].0,
                         _ => {
                             panic!("internal rendergraph error: using a non-texture as a renderpass attachment")
                         }
@@ -616,7 +617,7 @@ impl<'node> RenderGraph<'node> {
             RenderPassDepthStencilAttachment {
                 view: match resource {
                     GraphSubResource::ImportedTexture(region) => &active_imported_views[&region],
-                    GraphSubResource::Texture(region) => &active_views[&region],
+                    GraphSubResource::Texture(region) => &active_views[&region].0,
                     _ => {
                         panic!("internal rendergraph error: using a non-texture as a renderpass attachment")
                     }


### PR DESCRIPTION
## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues
None that I know of, but there's a related discussion on Matrix: https://matrix.to/#/!telLUrJoXXaQkubDie:matrix.org/$yWhwEvotAZGH9WMT1l5lRAOLjzNefA1XIzlicG9RSos?via=matrix.org&via=t2bot.io

## Description
I added a way to get a &Texture out of the render graph while inside a node. This is required to interact with some wgpu APIs (like copy from texture to buffer) which require a texture, not a view.