### PR TITLE
Fix incorrect comment in opaque.wgsl

### DIFF
--- a/rend3-routine/shaders/src/opaque.wgsl
+++ b/rend3-routine/shaders/src/opaque.wgsl
@@ -305,22 +305,22 @@ fn get_pixel_data_inner(material_arg: Material, s: sampler, vs_out: VertexOutput
         // Red: AO
         //
         // In roughness texture (FLAGS_AOMR_SPLIT):
-        // Green: Roughness
-        // Blue: Metallic
-        //
-        // In roughness texture (FLAGS_AOMR_SWIZZLED_SPLIT):
         // Red: Roughness
         // Green: Metallic
+        //
+        // In roughness texture (FLAGS_AOMR_SWIZZLED_SPLIT):
+        // Green: Roughness
+        // Blue: Metallic
         if (has_roughness_texture(&material)) {
             let texture_read = roughness_texture(&material, s, coords, uvdx, uvdy);
-            var mr: vec2<f32>;
+            var rm: vec2<f32>;
             if (extract_material_flag(material.flags, FLAGS_AOMR_SWIZZLED_SPLIT)) {
-                mr = texture_read.gb;
+                rm = texture_read.gb;
             } else {
-                mr = texture_read.rg;
+                rm = texture_read.rg;
             }
-            pixel.perceptual_roughness = material.roughness * mr[0];
-            pixel.metallic = material.metallic * mr[1];
+            pixel.perceptual_roughness = material.roughness * rm[0];
+            pixel.metallic = material.metallic * rm[1];
         } else {
             pixel.perceptual_roughness = material.roughness;
             pixel.metallic = material.metallic;


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

## Description
This is a purely non-functional change that updates the comments and variable names in `opaque.wgsl` to accurately reflect the data passed from the CPU side: (https://github.com/BVE-Reborn/rend3/blob/trunk/rend3-routine/src/pbr/material.rs#L243-L254)