### PR TITLE
[sketch] Upgrade to wgpu 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,5 @@ lto = "thin"
 # wgpu-core = { path = "../wgpu/wgpu-core" }
 # wgpu-hal = { path = "../wgpu/wgpu-hal" }
 # wgpu-types = { path = "../wgpu/wgpu-types" }
+
+wasm-bindgen = { git = "https://github.com/Rob2309/wasm-bindgen/", branch = "wasi-abi" }

--- a/examples/scene-viewer/Cargo.toml
+++ b/examples/scene-viewer/Cargo.toml
@@ -48,7 +48,7 @@ rend3-routine = { version = "^0.3.0", path = "../../rend3-routine" }
 rustc-hash = "1"
 smallvec = "1"
 tracy-client = { version = "0.14", optional = true }
-wgpu-profiler = "0.11.0"
+wgpu-profiler = "0.12.0"
 winit = "0.28"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -16,5 +16,5 @@ egui = "0.21.0"
 egui-wgpu = "0.21"
 glam = "0.22"
 rend3 = { version = "^0.3.0", path = "../rend3" }
-wgpu = "0.15"
-wgpu-types = "0.15"
+wgpu = "0.16.1"
+wgpu-types = "0.16.0"

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -22,7 +22,7 @@ rend3 = { version = "0.3.0", path = "../rend3" }
 rend3-routine = { version = "0.3.0", path = "../rend3-routine" }
 thiserror = { version = "1" }
 winit = "0.28"
-wgpu = "0.15"
+wgpu = "0.16.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -25,8 +25,8 @@ profiling = {version = "1", default-features = false }
 rend3 = { version = "^0.3.0", path = "../rend3" }
 rust-embed = { version = "6", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
-wgpu = "0.15"
-wgpu-profiler = "0.11.0"
+wgpu = "0.16.1"
+wgpu-profiler = "0.12.0"
 
 [dev-dependencies]
 codespan-reporting = "0.11"

--- a/rend3-routine/shaders/src/cull.wgsl
+++ b/rend3-routine/shaders/src/cull.wgsl
@@ -70,7 +70,7 @@ fn cs_main(
     let index1 = vertex_buffer[object.first_index + index_1_index];
     let index2 = vertex_buffer[object.first_index + index_2_index];
 
-    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 0u] = local_object_index << 24u | index0 & ((1u << 24u) - 1u);
-    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 1u] = local_object_index << 24u | index1 & ((1u << 24u) - 1u);
-    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 2u] = local_object_index << 24u | index2 & ((1u << 24u) - 1u);
+    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 0u] = (local_object_index << 24u) | (index0 & ((1u << 24u) - 1u));
+    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 1u] = (local_object_index << 24u) | (index1 & ((1u << 24u) - 1u));
+    output_buffer[(culling_job.base_output_invocation + gid.x) * 3u + 2u] = (local_object_index << 24u) | (index2 & ((1u << 24u) - 1u));
 }

--- a/rend3-routine/shaders/src/depth.wgsl
+++ b/rend3-routine/shaders/src/depth.wgsl
@@ -75,13 +75,13 @@ fn vs_main(@builtin(instance_index) shadow_number: u32, @builtin(vertex_index) v
 }
 
 {{#if (eq profile "GpuDriven")}}
-type Material = GpuMaterialData;
+alias Material = GpuMaterialData;
 
 fn has_albedo_texture(material: ptr<function, Material>) -> bool { return (*material).albedo_tex != 0u; }
 
 fn albedo_texture(material: ptr<function, Material>, samp: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> { return textureSampleGrad(textures[(*material).albedo_tex - 1u], samp, coords, ddx, ddy); }
 {{else}}
-type Material = CpuMaterialData;
+alias Material = CpuMaterialData;
 
 fn has_albedo_texture(material: ptr<function, Material>) -> bool { return bool(((*material).texture_enable >> 0u) & 0x1u); }
 

--- a/rend3-routine/shaders/src/opaque.wgsl
+++ b/rend3-routine/shaders/src/opaque.wgsl
@@ -119,7 +119,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 }
 
 {{#if (eq profile "GpuDriven")}}
-type Material = GpuMaterialData;
+alias Material = GpuMaterialData;
 
 fn has_albedo_texture(material: ptr<function, Material>) -> bool { return (*material).albedo_tex != 0u; }
 fn has_normal_texture(material: ptr<function, Material>) -> bool { return (*material).normal_tex != 0u; }
@@ -143,7 +143,7 @@ fn emissive_texture(material: ptr<function, Material>, samp: sampler, coords: ve
 fn anisotropy_texture(material: ptr<function, Material>, samp: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> { return textureSampleGrad(textures[(*material).anisotropy_tex - 1u], samp, coords, ddx, ddy); }
 fn ambient_occlusion_texture(material: ptr<function, Material>, samp: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> { return textureSampleGrad(textures[(*material).ambient_occlusion_tex - 1u], samp, coords, ddx, ddy); }
 {{else}}
-type Material = CpuMaterialData;
+alias Material = CpuMaterialData;
 
 fn has_albedo_texture(material: ptr<function, Material>) -> bool { return bool(((*material).texture_enable >> 0u) & 0x1u); }
 fn has_normal_texture(material: ptr<function, Material>) -> bool { return bool(((*material).texture_enable >> 1u) & 0x1u); }

--- a/rend3-routine/src/common/samplers.rs
+++ b/rend3-routine/src/common/samplers.rs
@@ -71,7 +71,7 @@ fn create_sampler(device: &Device, filter: FilterMode, compare: Option<CompareFu
         lod_min_clamp: 0.0,
         lod_max_clamp: 100.0,
         compare,
-        anisotropy_clamp: NonZeroU8::new(16),
+        anisotropy_clamp: 16,
         border_color: None,
     })
 }

--- a/rend3-routine/src/common/samplers.rs
+++ b/rend3-routine/src/common/samplers.rs
@@ -71,7 +71,7 @@ fn create_sampler(device: &Device, filter: FilterMode, compare: Option<CompareFu
         lod_min_clamp: 0.0,
         lod_max_clamp: 100.0,
         compare,
-        anisotropy_clamp: 16,
+        anisotropy_clamp: 1,
         border_color: None,
     })
 }

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -41,7 +41,7 @@ fn create_pipeline(
         )),
     });
 
-    let fs_entry_point = if output_format.describe().srgb {
+    let fs_entry_point = if output_format.is_srgb() {
         "fs_main_scene"
     } else {
         "fs_main_monitor"

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -19,4 +19,4 @@ glam = { version = "0.22", features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
-wgt = { package = "wgpu-types", version = "0.15" }
+wgt = { package = "wgpu-types", version = "0.16" }

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -57,8 +57,8 @@ serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "0.15"
-wgpu-profiler = "0.11.0"
+wgpu = "0.16.1"
+wgpu-profiler = "0.12.0"
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/src/graph/graph.rs
+++ b/rend3/src/graph/graph.rs
@@ -3,7 +3,6 @@ use std::{
     cell::{RefCell, UnsafeCell},
     collections::hash_map::Entry,
     marker::PhantomData,
-    num::NonZeroU32,
     ops::Range,
     sync::Arc,
 };
@@ -341,7 +340,7 @@ impl<'node> RenderGraph<'node> {
                     if let Entry::Vacant(vacant) = active_views.entry(region) {
                         let view = active_textures[&region.idx].create_view(&TextureViewDescriptor {
                             base_array_layer: region.layer_start,
-                            array_layer_count: Some(NonZeroU32::new(region.layer_end - region.layer_start).unwrap()),
+                            array_layer_count: Some(region.layer_end - region.layer_start),
                             ..TextureViewDescriptor::default()
                         });
                         vacant.insert(view);
@@ -354,9 +353,7 @@ impl<'node> RenderGraph<'node> {
                                 .as_texture_ref()
                                 .create_view(&TextureViewDescriptor {
                                     base_array_layer: region.layer_start,
-                                    array_layer_count: Some(
-                                        NonZeroU32::new(region.layer_end - region.layer_start).unwrap(),
-                                    ),
+                                    array_layer_count: Some(region.layer_end - region.layer_start),
                                     ..TextureViewDescriptor::default()
                                 });
                         vacant.insert(view);

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -40,9 +40,9 @@ pub const OPTIONAL_FEATURES: Features = Features::from_bits_truncate(
     Features::DEPTH_CLIP_CONTROL.bits()
         | Features::TEXTURE_COMPRESSION_BC.bits()
         | Features::TEXTURE_COMPRESSION_ETC2.bits()
-        | Features::TEXTURE_COMPRESSION_ASTC_LDR.bits()
+        | Features::TEXTURE_COMPRESSION_ASTC.bits()
         | Features::TIMESTAMP_QUERY.bits()
-        | Features::WRITE_TIMESTAMP_INSIDE_PASSES.bits(),
+        | Features::TIMESTAMP_QUERY_INSIDE_PASSES.bits(),
 );
 
 /// Check that all required features for a given profile are present in the feature

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -1,7 +1,5 @@
 //! Mipmap generation tools.
 
-use std::num::NonZeroU32;
-
 use arrayvec::ArrayVec;
 use parking_lot::RwLock;
 use rend3_types::TextureFormat;
@@ -67,7 +65,7 @@ impl MipmapGenerator {
             lod_min_clamp: 0.0,
             lod_max_clamp: 100.0,
             compare: None,
-            anisotropy_clamp: None,
+            anisotropy_clamp: 1,
             border_color: None,
         });
 
@@ -152,7 +150,7 @@ impl MipmapGenerator {
                 texture.create_view(&TextureViewDescriptor {
                     label: None,
                     base_mip_level: mip_level,
-                    mip_level_count: NonZeroU32::new(1),
+                    mip_level_count: Some(1),
                     ..Default::default()
                 })
             })


### PR DESCRIPTION
Sketch for now, fulfilling CI is blocked on `imgui-wgpu`. However there are a few changes that might warrant discussion so opening this anyways.

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [ ] relevant examples/test cases run
  - [ ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

#487 

## Description

The most troubling portion is the treatment of TextureFormats with
aspect-dependent block dimensions or components, introduced in wgpu 0.16.
When these are used internally they will always be queried without any such tailoring.