### PR TITLE
Fix resize observer with non-1 pixel ratios on wasm

### DIFF
--- a/rend3-framework/src/resize_observer.rs
+++ b/rend3-framework/src/resize_observer.rs
@@ -18,8 +18,8 @@ export function __wasm_rend3_framework_register_resize_observer_impl(element, se
         } else {
             console.error("Cannot get borderBoxSize from ResizeObserver entry!");
         }
-        const height = size.blockSize;
-        const width = size.inlineSize;
+        const height = size.blockSize * window.devicePixelRatio;
+        const width = size.inlineSize * window.devicePixelRatio;
         send_msg_resized(width, height);
     });
     resizeObserver.observe(element);


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [x] `cargo fmt` has been ran
  - [x] `cargo clippy` reports no issues
  - [x] `cargo test` succeeds
  - [x] `cargo rend3-doc` has no warnings
  - [x] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.


