### PR TITLE
Store PotentialAdapters as Vec, not ArrayVec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Fixed building with `profiling/profile-with-tracing`. @SparkyPotato
 - Fixed panic when a mesh object with a skeleton was despawned. @setzer22
 - Fixed forward pass not writing to depth when no depth prepass was used. @IsseW
+- Fixed panic in IAD creation when system has more than 4 wgpu adapters. @marceline-cramer
 
 ## v0.3.0
 

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use arrayvec::ArrayVec;
 use wgpu::{
     Adapter, AdapterInfo, Backend, Backends, BufferAddress, Device, DeviceDescriptor, DeviceType, Features,
     Gles3MinorVersion, Instance, InstanceFlags, Limits, Queue,
@@ -463,7 +462,7 @@ pub async fn create_iad(
         flags: InstanceFlags::default(),
     });
 
-    let mut valid_adapters = FastHashMap::<Backend, ArrayVec<PotentialAdapter<Adapter>, 4>>::default();
+    let mut valid_adapters = FastHashMap::<Backend, Vec<PotentialAdapter<Adapter>>>::default();
 
     for backend in &default_backend_order {
         profiling::scope!("enumerating backend");
@@ -479,7 +478,7 @@ pub async fn create_iad(
             .await
             .into_iter();
 
-        let mut potential_adapters = ArrayVec::<PotentialAdapter<Adapter>, 4>::new();
+        let mut potential_adapters = Vec::new();
         for (idx, adapter) in adapters.enumerate() {
             let info = adapter.get_info();
             let limits = adapter.limits();


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x] relevant examples/test cases run
  - [x] changes added to changelog
    - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

## Description

Storing `PotentialAdapter` in an `ArrayVec` goes out of bounds and panics when the system has more than 4 wgpu adapters available. Instead of increasing the capacity of the `ArrayVec`, I've simply converted it to a `Vec` instead.
