### PR TITLE
Fix CI Shield Badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rend3
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/BVE-Reborn/rend3/CI)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/BVE-Reborn/rend3/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/rend3)](https://crates.io/crates/rend3)
 [![Documentation](https://docs.rs/rend3/badge.svg)](https://docs.rs/rend3)
 ![License](https://img.shields.io/crates/l/rend3)


### PR DESCRIPTION
## Checklist

Not relevant

## Related Issues

None (as far as I know)

## Description

Fixes CI shield badge in `README.md`.
See: https://github.com/badges/shields/issues/8671

### Before 
![image](https://github.com/BVE-Reborn/rend3/assets/51504825/5c85d51c-a5c6-46a2-9c0a-d6ba435bf5bf)
### After
![image](https://github.com/BVE-Reborn/rend3/assets/51504825/4b09f4b5-f3d6-4d21-9610-e1cde01879a0)

