### PR TITLE
Resync with WGPU 0.20.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Versions
 
+- [v0.20.0] (#v0.20.0)
 - [Unreleased](#unreleased)
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
@@ -28,6 +29,16 @@ Per Keep a Changelog there are 6 main categories of changes:
 - [v0.0.2](#v002)
 - [v0.0.1](#v001)
 - [Diffs](#diffs)
+
+## v0.20.0
+
+### Major Changes
+There will be basic maintenance to keep Rend3 alive. (JN).
+
+### Changes
+- Version number advanced to 0.20. From now on, the version will generally follow WGPU.
+- Incorporated all items listed as "Unreleased".
+- Upgraded dependent packages to WGPU 0.20, and appropriate versions of Egui and Winit.
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ Per Keep a Changelog there are 6 main categories of changes:
 - [v0.0.1](#v001)
 - [Diffs](#diffs)
 
+## v0.23.1
+
+### Major Changes
+None
+
+### Changes
+- Upgraded dependent packages to WGPU 0.23, and appropriate versions of Egui and Winit.
+### Fixes
+- Probably fixed issue 3: 
+- Fixed issue 4: https://github.com/John-Nagle/rend3-hp/issues/4
+
 ## v0.20.0
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ None
 ### Changes
 - Upgraded dependent packages to WGPU 0.23, and appropriate versions of Egui and Winit.
 ### Fixes
-- Probably fixed issue 3: 
+- Probably fixed issue 3: https://github.com/John-Nagle/rend3-hp/issues/3
 - Fixed issue 4: https://github.com/John-Nagle/rend3-hp/issues/4
 
 ## v0.20.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.24.2"
 wgpu = "^24.0.1"
 wgpu-types = "^24.0.0"
 wgpu-profiler = "^0.21.0"
+glam = "^0.29"
 
 [profile.ci]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
     "rend3-types",
 ]
 
+[workspace.package]
+version = "0.24.1"
+
 [profile.ci]
 inherits = "dev"
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,3 @@ opt-level = 3
 [profile.release]
 debug = true
 lto = "thin"
-
-#   Temporary override of range-alloc, where a fix was not pushed to crates.io.
-[patch.crates-io]
-range-alloc = {version = "0.1.3", git = 'https://github.com/gfx-rs/range-alloc.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,17 +26,3 @@ opt-level = 3
 [profile.release]
 debug = true
 lto = "thin"
-
-[patch.crates-io]
-# wgpu = { git = "https://github.com/gfx-rs/wgpu.git", rev = "fac4731288117d951d0944d96cf0b00fa006dd6c" }
-# wgpu-core = { git = "https://github.com/gfx-rs/wgpu.git", rev = "fac4731288117d951d0944d96cf0b00fa006dd6c" }
-# wgpu-hal = { git = "https://github.com/gfx-rs/wgpu.git", rev = "fac4731288117d951d0944d96cf0b00fa006dd6c" }
-# wgpu-types = { git = "https://github.com/gfx-rs/wgpu.git", rev = "fac4731288117d951d0944d96cf0b00fa006dd6c" }
-# wgpu = { git = "https://github.com/cwfitzgerald/wgpu.git", rev = "bda861f77e0ca0b97697850ad19d19a8b8f1cc9c" }
-# wgpu-core = { git = "https://github.com/cwfitzgerald/wgpu.git", rev = "bda861f77e0ca0b97697850ad19d19a8b8f1cc9c" }
-# wgpu-hal = { git = "https://github.com/cwfitzgerald/wgpu.git", rev = "bda861f77e0ca0b97697850ad19d19a8b8f1cc9c" }
-# wgpu-types = { git = "https://github.com/cwfitzgerald/wgpu.git", rev = "bda861f77e0ca0b97697850ad19d19a8b8f1cc9c" }
-# wgpu = { path = "../wgpu/wgpu" }
-# wgpu-core = { path = "../wgpu/wgpu-core" }
-# wgpu-hal = { path = "../wgpu/wgpu-hal" }
-# wgpu-types = { path = "../wgpu/wgpu-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ opt-level = 3
 [profile.release]
 debug = true
 lto = "thin"
+
+#   Temporary override of out of date WGPU profiler
+[patch.crates-io]
+wgpu-profiler = { version = "^0.18.3", git = 'https://github.com/John-Nagle/wgpu-profiler' }
+egui-wgpu = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
+epaint = { version = "0.29.1", git = 'https://github.com/emilk/egui.git' }
+emath = { version = "0.29.1", git = 'git+https://github.com/emilk/egui.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,12 @@ members = [
 ]
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
+
+[workspace.dependencies]
+wgpu = "^24.0.1"
+wgpu-types = "^24.0.0"
+wgpu-profiler = "^0.21.0"
 
 [profile.ci]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ opt-level = 3
 [profile.release]
 debug = true
 lto = "thin"
+
+#   Override egui - doesn't work.
+[patch.crates-io]
+egui = { git = "https://github.com/emilk/egui", branch = "master"}
+egui-wgpu = { git = "https://github.com/emilk/egui", branch = "master"}
+epaint = { git = "https://github.com/emilk/egui", branch = "master"}
+## wgpu = { version = "22.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,6 @@ opt-level = 3
 debug = true
 lto = "thin"
 
-#   Temporary override of out of date WGPU profiler
-####[patch.crates-io]
-####wgpu-profiler = { version = "^0.18.3", git = 'https://github.com/John-Nagle/wgpu-profiler' }
-####egui = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
-####egui-wgpu = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
-####epaint = { version = "0.29.1", git = 'https://github.com/emilk/egui.git' }
-####emath = { version = "0.29.1", git = 'git+https://github.com/emilk/egui.git' }
+#   Temporary override of range-alloc, where a fix was not pushed to crates.io.
+[patch.crates-io]
+range-alloc = {version = "0.1.3", git = 'https://github.com/gfx-rs/range-alloc.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,3 @@ opt-level = 3
 [profile.release]
 debug = true
 lto = "thin"
-
-#   Override egui - doesn't work.
-[patch.crates-io]
-egui = { git = "https://github.com/emilk/egui", branch = "master"}
-egui-wgpu = { git = "https://github.com/emilk/egui", branch = "master"}
-epaint = { git = "https://github.com/emilk/egui", branch = "master"}
-## wgpu = { version = "22.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ debug = true
 lto = "thin"
 
 #   Temporary override of out of date WGPU profiler
-[patch.crates-io]
-wgpu-profiler = { version = "^0.18.3", git = 'https://github.com/John-Nagle/wgpu-profiler' }
-egui = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
-egui-wgpu = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
-epaint = { version = "0.29.1", git = 'https://github.com/emilk/egui.git' }
-emath = { version = "0.29.1", git = 'git+https://github.com/emilk/egui.git' }
+####[patch.crates-io]
+####wgpu-profiler = { version = "^0.18.3", git = 'https://github.com/John-Nagle/wgpu-profiler' }
+####egui = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
+####egui-wgpu = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
+####epaint = { version = "0.29.1", git = 'https://github.com/emilk/egui.git' }
+####emath = { version = "0.29.1", git = 'git+https://github.com/emilk/egui.git' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lto = "thin"
 #   Temporary override of out of date WGPU profiler
 [patch.crates-io]
 wgpu-profiler = { version = "^0.18.3", git = 'https://github.com/John-Nagle/wgpu-profiler' }
+egui = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
 egui-wgpu = { version = "0.29.1", git = 'https://github.com/emilk/egui.git'}
 epaint = { version = "0.29.1", git = 'https://github.com/emilk/egui.git' }
 emath = { version = "0.29.1", git = 'git+https://github.com/emilk/egui.git' }

--- a/NOTES.md
+++ b/NOTES.md
@@ -19,46 +19,102 @@ https://users.rust-lang.org/t/unexpected-borrowed-data-escapes-outside-of-closur
 RenderPass and Controller ownership is currently manipulated by unsafe code. 
 That needs to be figured out. 
 
-###Trouble spots:
-
-* take_rpass
+###Trouble spot: take_rpass
   
-  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/encpass.rs#L74
+https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/encpass.rs#L74
   
-        pub(super) enum RenderGraphEncoderOrPassInner<'a, 'pass> {
-            Encoder(&'a mut CommandEncoder),
-            RenderPass(&'a mut RenderPass<'pass>),
-            #[default]
-            None,
-        }   
+    pub(super) enum RenderGraphEncoderOrPassInner<'a, 'pass> {
+        Encoder(&'a mut CommandEncoder),
+        RenderPass(&'a mut RenderPass<'pass>),
+        #[default]
+        None,
+    }   
   
-        pub struct RenderGraphEncoderOrPass<'a, 'pass>(pub(super) RenderGraphEncoderOrPassInner<'a, 'pass>);
-        ...
-        pub fn take_rpass(&mut self, _handle: DeclaredDependency<RenderPassHandle>) -> &'a mut RenderPass<'pass> {
-        match mem::take(&mut self.0) {
+    pub struct RenderGraphEncoderOrPass<'a, 'pass>(pub(super) RenderGraphEncoderOrPassInner<'a, 'pass>);
+    ...
+    pub fn take_rpass(&mut self, _handle: DeclaredDependency<RenderPassHandle>) -> &'a mut RenderPass<'pass> {
+    match mem::take(&mut self.0) {
         
-  This in itself seems legit, i.e. safe. Except that it's taking a mutable reference, not the object itself.
-  There can only be one such mutable reference. Where does this come from?
+This in itself seems legit, i.e. safe. Except that it's taking a mutable reference, not the object itself.
+There can only be one such mutable reference. Where does this come from?
   
-  Around here:
+Around here:
   
   https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/graph.rs#L451
   
-  where there is unsafe code to seemingly allow two mutable references to the same object to exist simultaneously.
+where there is unsafe code to seemingly allow two mutable references to the same object to exist simultaneously.
   
-      // SAFETY: There is no active renderpass to borrow this. This reference lasts for the duration of
-      // the call to exec.
-      None => RenderGraphEncoderOrPassInner::Encoder(unsafe { &mut *encoder_cell.get() }),
+    // SAFETY: There is no active renderpass to borrow this. This reference lasts for the duration of
+    // the call to exec.
+    None => RenderGraphEncoderOrPassInner::Encoder(unsafe { &mut *encoder_cell.get() }),
       
-  Note that this is not an assertion that the code here is safe.
-  It is an unchecked constraint on the rest of the program.
+Note that this is not an assertion that the code here is safe.
+It is an unchecked constraint on the rest of the program.
   
-  Why is this not done with a RefCell and .borrow_mut?
+Why is this not done with a RefCell and .borrow_mut?
   
-  Other than the mess around RenderPass, there's not that much unsafe code in rend3.
-  This might be fixable.
+Other than the mess around RenderPass, there's not that much unsafe code in rend3.
+This might be fixable.
   
-  Maybe if we pass around something that has a RefCell<RenderGraphEncoderOrPassInner>
-  to everybody who needs that...
+Maybe if we pass around something that has a RefCell<RenderGraphEncoderOrPassInner>
+to everybody who needs that...
+But that encapsulates a mutable reference. Who actually *owns* the thing?
+Question: if we put RenderPass and Encoder inside an Rc<RefCell<>>, will that work?
+Or will we panic at borrows?
+Worth a try.
+
+## 2024-10-13
+
+Who actually owns RenderPass and Encoder?
+
+    RenderGraphEncoderOrPassInner holds an &mut of CommandEncoder or RenderPass
+
+Who actually creates RenderGraphEncoderOrPassInner?
+* Created in graph.rs execute
+
+  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/graph.rs#L451
+
+      RenderGraphEncoderOrPassInner::RenderPass(rpass)
+
+  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/graph.rs#L455
+
+       None => RenderGraphEncoderOrPassInner::Encoder(unsafe { &mut *encoder_cell.get() }),
+ 
+  Unsafe code. Is this really necessary?
+  
+  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/graph.rs#L484
+  
+  Same situation.
+  
+  That's a get from an UnsafeCell. That's probably what should be a RefCell.
+  The UnsafeCell actually owns the encoder. 
+  Who owns the RenderPass? 
+  The caller of 
+      create_rpass_from_desc
+  
+### First cut at design:
+
+      create_rpass_from_desc
+
+returns an Rc<RefCell<RenderPass>>.
+
+At line 391 in graph.rs,
+  encoder_cell becomes an Rc<RefCell>> of a new command encoder.
+  
+Similarly for rpass_temps_cell.
+
+RenderGraphEncoderOrPassInner must hold an Rc<RefCell<>> for each item.
+
+So where do we do the borrows?
+
+At the unsafe points? Probably.
+
+What about take_rpass? 
+Do the borrow at self.internal.render in lib.rs? 
+
+This will probably all compile and it's all safe code. If the comments about safety are true,
+the borrow_mut calls should not fail. We will see.
+
+
   
   

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,64 @@
+# Development notes
+John Nagle
+nagle@animats.com
+
+Reviving Rend3 after its abandonment.
+
+## 2024-10-12
+
+Changes to WGPU have broken Rend3. The worst change is
+
+https://github.com/gfx-rs/wgpu/pull/5884
+
+which changes the lifetime of "RenderPass" and Encoder to 'static
+
+which generates this problem:
+
+https://users.rust-lang.org/t/unexpected-borrowed-data-escapes-outside-of-closure-for-generic/119501/4
+
+RenderPass and Controller ownership is currently manipulated by unsafe code. 
+That needs to be figured out. 
+
+###Trouble spots:
+
+* take_rpass
+  
+  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/encpass.rs#L74
+  
+        pub(super) enum RenderGraphEncoderOrPassInner<'a, 'pass> {
+            Encoder(&'a mut CommandEncoder),
+            RenderPass(&'a mut RenderPass<'pass>),
+            #[default]
+            None,
+        }   
+  
+        pub struct RenderGraphEncoderOrPass<'a, 'pass>(pub(super) RenderGraphEncoderOrPassInner<'a, 'pass>);
+        ...
+        pub fn take_rpass(&mut self, _handle: DeclaredDependency<RenderPassHandle>) -> &'a mut RenderPass<'pass> {
+        match mem::take(&mut self.0) {
+        
+  This in itself seems legit, i.e. safe. Except that it's taking a mutable reference, not the object itself.
+  There can only be one such mutable reference. Where does this come from?
+  
+  Around here:
+  
+  https://github.com/BVE-Reborn/rend3/blob/d088a841b0469d07d5a7ff3f4d784e97b4a194d5/rend3/src/graph/graph.rs#L451
+  
+  where there is unsafe code to seemingly allow two mutable references to the same object to exist simultaneously.
+  
+      // SAFETY: There is no active renderpass to borrow this. This reference lasts for the duration of
+      // the call to exec.
+      None => RenderGraphEncoderOrPassInner::Encoder(unsafe { &mut *encoder_cell.get() }),
+      
+  Note that this is not an assertion that the code here is safe.
+  It is an unchecked constraint on the rest of the program.
+  
+  Why is this not done with a RefCell and .borrow_mut?
+  
+  Other than the mess around RenderPass, there's not that much unsafe code in rend3.
+  This might be fixable.
+  
+  Maybe if we pass around something that has a RefCell<RenderGraphEncoderOrPassInner>
+  to everybody who needs that...
+  
+  

--- a/NOTES.md
+++ b/NOTES.md
@@ -117,7 +117,15 @@ the borrow_mut calls should not fail. We will see.
 
 ## 2024-10-14
 
-Fix all other compile errors from WGPU change.
+Fix all other compile errors from Winit changes. [DONE]
+
+## 2024-10-16
+
+Completed fixing Winit problems, with event loop disabled.
+Time to do the above changes to Rend3.
+
+
+
 
 
   

--- a/NOTES.md
+++ b/NOTES.md
@@ -115,6 +115,10 @@ Do the borrow at self.internal.render in lib.rs?
 This will probably all compile and it's all safe code. If the comments about safety are true,
 the borrow_mut calls should not fail. We will see.
 
+## 2024-10-14
+
+Fix all other compile errors from WGPU change.
+
 
   
   

--- a/NOTES.md
+++ b/NOTES.md
@@ -124,6 +124,10 @@ Fix all other compile errors from Winit changes. [DONE]
 Completed fixing Winit problems, with event loop disabled.
 Time to do the above changes to Rend3.
 
+Most of it now compiles.
+
+Trouble at line 507 of graph.rs
+
 
 
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rend3-examples-package"
 license = "MIT OR Apache-2.0 OR Zlib"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 publish = false
@@ -48,17 +48,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.20", path = "../rend3" }
+rend3 = { version = "^0.22", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.20", path = "../rend3-anim" }
+rend3-anim = { version = "^0.22", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.20", path = "../rend3-egui" }
+rend3-egui = { version = "^0.22", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.20", path = "../rend3-routine" }
+rend3-routine = { version = "^0.22", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.20", path = "../rend3-framework" }
+rend3-framework = { version = "^0.22", path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.20", path = "../rend3-gltf" }
+rend3-gltf = { version = "^0.22", path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "1"
 # Instant but portable to the web
@@ -83,7 +83,7 @@ wasm-bindgen-futures = "0.4"
 ndk-glue = { version = "0.7", features = ["logger"] }
 
 [dev-dependencies]
-rend3-test = { version = "^0.20.0", path = "../rend3-test" }
+rend3-test = { version = "^0.22.0", path = "../rend3-test" }
 tokio = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,9 @@ crate-type = ["lib", "cdylib"]
 name = "rend3-examples"
 path = "src/main.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+# Enable Tracy tracing for scene-viewer
+tracy = ["tracy-client"]
 
 [dependencies]
 # error handling
@@ -69,6 +71,7 @@ winit = "0.30"
 wgpu = "23.0"
 # Profiling with wgpu
 wgpu-profiler = "0.19"
+tracy-client = { version = "0.17", optional=true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # error handling
 anyhow = "1"
 # The egui immediate mode gui library
-egui = "0.28"
+egui = "0.29"
 # Winit integration with egui (turn off the clipboard feature)
 egui-winit = { version = "0.28", default-features = false, features = ["links", "wayland"] }
 # logging

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rend3-examples-package"
 license = "MIT OR Apache-2.0 OR Zlib"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 publish = false
@@ -50,17 +50,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.23.1", path = "../rend3" }
+rend3 = { path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.23.1", path = "../rend3-anim" }
+rend3-anim = { path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.23.1", path = "../rend3-egui" }
+rend3-egui = { path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
+rend3-routine = { path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.23.1", path = "../rend3-framework" }
+rend3-framework = { path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.23.1", path = "../rend3-gltf" }
+rend3-gltf = { path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "1"
 # Instant but portable to the web
@@ -86,7 +86,7 @@ wasm-bindgen-futures = "0.4"
 ndk-glue = { version = "0.7", features = ["logger"] }
 
 [dev-dependencies]
-rend3-test = { version = "^0.23.0", path = "../rend3-test" }
+rend3-test = { path = "../rend3-test" }
 tokio = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,9 +20,9 @@ path = "src/main.rs"
 # error handling
 anyhow = "1"
 # The egui immediate mode gui library
-egui = "0.26"
+egui = "0.28"
 # Winit integration with egui (turn off the clipboard feature)
-egui-winit = { version = "0.26", default-features = false, features = ["links", "wayland"] }
+egui-winit = { version = "0.28", default-features = false, features = ["links", "wayland"] }
 # logging
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 # Linear algebra library
@@ -48,15 +48,15 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.3.0", path = "../rend3" }
+rend3 = { version = "^0.3", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.3.0", path = "../rend3-anim" }
+rend3-anim = { version = "^0.3", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.3.0", path = "../rend3-egui" }
+rend3-egui = { version = "^0.3", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.3.0", path = "../rend3-routine" }
+rend3-routine = { version = "^0.3", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.3.0", path = "../rend3-framework" }
+rend3-framework = { version = "^0.3", path = "../rend3-framework" }
 # Import gltf models
 rend3-gltf = { version = "^0.3.0", path = "../rend3-gltf" }
 # Opening URL's
@@ -66,9 +66,9 @@ web-time = "1.1"
 # windowing
 winit = "0.29.4"
 # Integration with wgpu
-wgpu = "0.19.0"
+wgpu = "0.20"
 # Profiling with wgpu
-wgpu-profiler = "0.16.0"
+wgpu-profiler = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,9 +20,9 @@ path = "src/main.rs"
 # error handling
 anyhow = "1"
 # The egui immediate mode gui library
-egui = "0.29"
+egui = "0.30"
 # Winit integration with egui (turn off the clipboard feature)
-egui-winit = { version = "0.29", default-features = false, features = ["links", "wayland"] }
+egui-winit = { version = "0.30", default-features = false, features = ["links", "wayland"] }
 # logging
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 # Linear algebra library
@@ -68,7 +68,7 @@ winit = "0.30"
 # Integration with wgpu
 wgpu = "23.0"
 # Profiling with wgpu
-wgpu-profiler = "0.18"
+wgpu-profiler = "0.19"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,17 +48,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.22", path = "../rend3" }
+rend3 = { version = "^0.22.1", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.22", path = "../rend3-anim" }
+rend3-anim = { version = "^0.22.1", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.22", path = "../rend3-egui" }
+rend3-egui = { version = "^0.22.1", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.22", path = "../rend3-routine" }
+rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.22", path = "../rend3-framework" }
+rend3-framework = { version = "^0.22.1", path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.22", path = "../rend3-gltf" }
+rend3-gltf = { version = "^0.22.1", path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "1"
 # Instant but portable to the web
@@ -66,7 +66,7 @@ web-time = "1.1"
 # windowing
 winit = "0.29.4"
 # Integration with wgpu
-wgpu = "0.20"
+wgpu = "22.1"
 # Profiling with wgpu
 wgpu-profiler = "0.17"
 
@@ -83,7 +83,7 @@ wasm-bindgen-futures = "0.4"
 ndk-glue = { version = "0.7", features = ["logger"] }
 
 [dev-dependencies]
-rend3-test = { version = "^0.22.0", path = "../rend3-test" }
+rend3-test = { version = "^0.22.1", path = "../rend3-test" }
 tokio = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 # Inline string
 indoc = "2"
 # Importing images
-image = { version = "0.24", default-features = false, features = [
+image = { version = "0.25", default-features = false, features = [
     "png",
     "jpeg",
     "tiff",
@@ -60,7 +60,7 @@ rend3-framework = { version = "^0.20", path = "../rend3-framework" }
 # Import gltf models
 rend3-gltf = { version = "^0.20", path = "../rend3-gltf" }
 # Opening URL's
-webbrowser = "0.8.2"
+webbrowser = "1"
 # Instant but portable to the web
 web-time = "1.1"
 # windowing

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rend3-examples-package"
 license = "MIT OR Apache-2.0 OR Zlib"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 publish = false
@@ -48,17 +48,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.3", path = "../rend3" }
+rend3 = { version = "^0.20", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.3", path = "../rend3-anim" }
+rend3-anim = { version = "^0.20", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.3", path = "../rend3-egui" }
+rend3-egui = { version = "^0.20", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.3", path = "../rend3-routine" }
+rend3-routine = { version = "^0.20", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.3", path = "../rend3-framework" }
+rend3-framework = { version = "^0.20", path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.3.0", path = "../rend3-gltf" }
+rend3-gltf = { version = "^0.20", path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "0.8.2"
 # Instant but portable to the web
@@ -83,7 +83,7 @@ wasm-bindgen-futures = "0.4"
 ndk-glue = { version = "0.7", features = ["logger"] }
 
 [dev-dependencies]
-rend3-test = { version = "^0.3.0", path = "../rend3-test" }
+rend3-test = { version = "^0.20.0", path = "../rend3-test" }
 tokio = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rend3-examples-package"
 license = "MIT OR Apache-2.0 OR Zlib"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 publish = false
@@ -48,17 +48,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.22.1", path = "../rend3" }
+rend3 = { version = "^0.23.0", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.22.1", path = "../rend3-anim" }
+rend3-anim = { version = "^0.23.0", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.22.1", path = "../rend3-egui" }
+rend3-egui = { version = "^0.23.0", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
+rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.22.1", path = "../rend3-framework" }
+rend3-framework = { version = "^0.23.0", path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.22.1", path = "../rend3-gltf" }
+rend3-gltf = { version = "^0.23.0", path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "1"
 # Instant but portable to the web
@@ -66,7 +66,7 @@ web-time = "1.1"
 # windowing
 winit = "0.30"
 # Integration with wgpu
-wgpu = "22.1"
+wgpu = "23.0"
 # Profiling with wgpu
 wgpu-profiler = "0.18"
 
@@ -83,7 +83,7 @@ wasm-bindgen-futures = "0.4"
 ndk-glue = { version = "0.7", features = ["logger"] }
 
 [dev-dependencies]
-rend3-test = { version = "^0.22.1", path = "../rend3-test" }
+rend3-test = { version = "^0.23.0", path = "../rend3-test" }
 tokio = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,13 +22,13 @@ tracy = ["tracy-client"]
 # error handling
 anyhow = "1"
 # The egui immediate mode gui library
-egui = "0.30"
+egui = "0.31"
 # Winit integration with egui (turn off the clipboard feature)
-egui-winit = { version = "0.30", default-features = false, features = ["links", "wayland"] }
+egui-winit = { version = "0.31", default-features = false, features = ["links", "wayland"] }
 # logging
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 # Linear algebra library
-glam = "0.28"
+glam = { workspace = true }
 # gltf model loading
 gltf = "1.4"
 # Channel

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,7 +26,7 @@ egui-winit = { version = "0.28", default-features = false, features = ["links", 
 # logging
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 # Linear algebra library
-glam = "0.25"
+glam = "0.28"
 # gltf model loading
 gltf = "1.4"
 # Channel
@@ -68,7 +68,7 @@ winit = "0.29.4"
 # Integration with wgpu
 wgpu = "22.1"
 # Profiling with wgpu
-wgpu-profiler = "0.17"
+wgpu-profiler = "0.18"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1"
 # The egui immediate mode gui library
 egui = "0.29"
 # Winit integration with egui (turn off the clipboard feature)
-egui-winit = { version = "0.28", default-features = false, features = ["links", "wayland"] }
+egui-winit = { version = "0.29", default-features = false, features = ["links", "wayland"] }
 # logging
 env_logger = { version = "0.11", default-features = false, features = ["auto-color", "humantime"] }
 # Linear algebra library
@@ -64,7 +64,7 @@ webbrowser = "1"
 # Instant but portable to the web
 web-time = "1.1"
 # windowing
-winit = "0.29.4"
+winit = "0.30"
 # Integration with wgpu
 wgpu = "22.1"
 # Profiling with wgpu

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rend3-examples-package"
 license = "MIT OR Apache-2.0 OR Zlib"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 publish = false
@@ -50,17 +50,17 @@ pico-args = "0.5"
 # block on async functions
 pollster = "0.3"
 # Renderer core
-rend3 = { version = "^0.23.0", path = "../rend3" }
+rend3 = { version = "^0.23.1", path = "../rend3" }
 # Play animations on imported gltf models
-rend3-anim = { version = "^0.23.0", path = "../rend3-anim" }
+rend3-anim = { version = "^0.23.1", path = "../rend3-anim" }
 # Egui integration with rend3
-rend3-egui = { version = "^0.23.0", path = "../rend3-egui" }
+rend3-egui = { version = "^0.23.1", path = "../rend3-egui" }
 # Programmable render list that dictates how the scene renders
-rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
+rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
 # Framework that deals with the event loop, setting up the renderer, and platform differences.
-rend3-framework = { version = "^0.23.0", path = "../rend3-framework" }
+rend3-framework = { version = "^0.23.1", path = "../rend3-framework" }
 # Import gltf models
-rend3-gltf = { version = "^0.23.0", path = "../rend3-gltf" }
+rend3-gltf = { version = "^0.23.1", path = "../rend3-gltf" }
 # Opening URL's
 webbrowser = "1"
 # Instant but portable to the web

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -68,9 +68,9 @@ web-time = "1.1"
 # windowing
 winit = "0.30"
 # Integration with wgpu
-wgpu = "23.0"
+wgpu = { workspace = true }
 # Profiling with wgpu
-wgpu-profiler = "0.19"
+wgpu-profiler = { workspace = true }
 tracy-client = { version = "0.17", optional=true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/src/animation/mod.rs
+++ b/examples/src/animation/mod.rs
@@ -34,7 +34,11 @@ fn update(renderer: &rend3::Renderer, delta: f32, animated_object: &mut Animated
 }
 
 impl rend3_framework::App for AnimationExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
+
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/animation/mod.rs
+++ b/examples/src/animation/mod.rs
@@ -161,7 +161,7 @@ pub fn main() {
     let app = AnimationExample::default();
     rend3_framework::start(
         app,
-        winit::window::WindowBuilder::new().with_title("animation-example").with_maximized(true),
+        winit::window::WindowAttributes::default().with_title("animation-example").with_maximized(true),
     );
 }
 

--- a/examples/src/animation/mod.rs
+++ b/examples/src/animation/mod.rs
@@ -106,7 +106,7 @@ impl rend3_framework::App for AnimationExample {
         self.animated_objects = vec![animated_object, animated_object2];
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         self.animated_objects.iter_mut().for_each(|animated_object| {
             update(context.renderer, context.delta_t_seconds, animated_object);
         });

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -183,7 +183,7 @@ impl rend3_framework::App for CubeExample {
 
 pub fn main() {
     let app = CubeExample::default();
-    rend3_framework::start(app, winit::window::WindowBuilder::new().with_title("cube-example").with_maximized(true));
+    rend3_framework::start(app, winit::window::WindowAttributes::default().with_title("cube-example").with_maximized(true));
 }
 
 #[cfg(test)]

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -134,7 +134,7 @@ impl rend3_framework::App for CubeExample {
         }
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         // Swap the instruction buffers so that our frame's changes can be processed.
         context.renderer.swap_instruction_buffers();
         // Evaluate our frame's world-change instructions

--- a/examples/src/cube/mod.rs
+++ b/examples/src/cube/mod.rs
@@ -61,7 +61,11 @@ pub struct CubeExample {
 }
 
 impl rend3_framework::App for CubeExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    //////const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/cube_no_framework/mod.rs
+++ b/examples/src/cube_no_framework/mod.rs
@@ -62,9 +62,10 @@ pub fn main() {
     // Create event loop and window
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
     let window = {
-        let mut builder = winit::window::WindowBuilder::new();
-        builder = builder.with_title("rend3 cube");
-        builder.build(&event_loop).expect("Could not build window")
+        let mut window_attributes = winit::window::WindowAttributes::default();
+        window_attributes = window_attributes.with_title("rend3 cube");
+        //////builder.build(&event_loop).expect("Could not build window")
+        event_loop.create_window(window_attributes).expect("Could not build window") // (JN) for winit 0.30
     };
 
     let window_size = window.inner_size();

--- a/examples/src/egui/mod.rs
+++ b/examples/src/egui/mod.rs
@@ -102,6 +102,7 @@ impl rend3_framework::App for EguiExample {
                 &windowing.window,
                 Some(context.scale_factor),
                 None,
+                None, // (JN) New max texture size field, not used.
             ))
         } else {
             None
@@ -165,7 +166,7 @@ impl rend3_framework::App for EguiExample {
         }
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         let data = self.data.as_mut().unwrap();
 
         let input = if let Some(window) = context.window {

--- a/examples/src/egui/mod.rs
+++ b/examples/src/egui/mod.rs
@@ -256,7 +256,7 @@ impl rend3_framework::App for EguiExample {
 
 pub fn main() {
     let app = EguiExample::default();
-    rend3_framework::start(app, winit::window::WindowBuilder::new().with_title("egui").with_maximized(true))
+    rend3_framework::start(app, winit::window::WindowAttributes::default().with_title("egui").with_maximized(true))
 }
 
 fn vertex(pos: [f32; 3]) -> glam::Vec3 {

--- a/examples/src/egui/mod.rs
+++ b/examples/src/egui/mod.rs
@@ -175,7 +175,7 @@ impl rend3_framework::App for EguiExample {
             egui::RawInput::default()
         };
 
-        data.context.begin_frame(input);
+        data.context.begin_pass(input);
 
         // Insert egui commands here
         let ctx = &data.context;
@@ -201,7 +201,7 @@ impl rend3_framework::App for EguiExample {
 
         // End the UI frame. Now let's draw the UI with our Backend, we could also
         // handle the output here
-        let egui::FullOutput { shapes, textures_delta, .. } = data.context.end_frame();
+        let egui::FullOutput { shapes, textures_delta, .. } = data.context.end_pass();
         let paint_jobs = data.context.tessellate(shapes, scale_factor);
 
         let input = rend3_egui::Input { clipped_meshes: &paint_jobs, textures_delta, context: data.context.clone() };

--- a/examples/src/egui/mod.rs
+++ b/examples/src/egui/mod.rs
@@ -17,7 +17,11 @@ struct EguiExample {
     rust_logo: egui::TextureId,
 }
 impl rend3_framework::App for EguiExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
+
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/scene_viewer/mod.rs
+++ b/examples/src/scene_viewer/mod.rs
@@ -579,7 +579,7 @@ impl rend3_framework::App for SceneViewer {
         }
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         profiling::scope!("RedrawRequested");
 
         if let Some(ref receiver) = self.loading_reciever {

--- a/examples/src/scene_viewer/mod.rs
+++ b/examples/src/scene_viewer/mod.rs
@@ -432,7 +432,11 @@ impl SceneViewer {
     }
 }
 impl rend3_framework::App for SceneViewer {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Right;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Right    // Unlike the other examples, scene_viewer is right-handed.
+    }
+
 
     fn create_iad<'a>(
         &'a mut self,

--- a/examples/src/scene_viewer/mod.rs
+++ b/examples/src/scene_viewer/mod.rs
@@ -20,7 +20,7 @@ use web_time::Instant;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, MouseButton, WindowEvent},
     keyboard::{KeyCode, PhysicalKey},
-    window::{Fullscreen, WindowBuilder},
+    window::{Fullscreen},
 };
 
 async fn load_skybox_image(loader: &rend3_framework::AssetLoader, data: &mut Vec<u8>, path: &str) {
@@ -698,7 +698,7 @@ impl rend3_framework::App for SceneViewer {
 pub fn main() {
     let app = SceneViewer::from_args();
 
-    let mut builder = WindowBuilder::new().with_title("scene-viewer").with_maximized(true);
+    let mut builder = winit::window::WindowAttributes::default().with_title("scene-viewer").with_maximized(true);
     if app.fullscreen {
         builder = builder.with_fullscreen(Some(Fullscreen::Borderless(None)));
     }

--- a/examples/src/skinning/mod.rs
+++ b/examples/src/skinning/mod.rs
@@ -107,7 +107,7 @@ impl rend3_framework::App for SkinningExample {
         }));
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         self.update_skeleton(context.renderer);
 
         // Swap the instruction buffers so that our frame's changes can be processed.

--- a/examples/src/skinning/mod.rs
+++ b/examples/src/skinning/mod.rs
@@ -159,7 +159,7 @@ pub fn main() {
     let app = SkinningExample::default();
     rend3_framework::start(
         app,
-        winit::window::WindowBuilder::new().with_title("skinning-example").with_maximized(true),
+        winit::window::WindowAttributes::default().with_title("skinning-example").with_maximized(true),
     );
 }
 

--- a/examples/src/skinning/mod.rs
+++ b/examples/src/skinning/mod.rs
@@ -56,7 +56,11 @@ impl SkinningExample {
 }
 
 impl rend3_framework::App for SkinningExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
+
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/static_gltf/mod.rs
+++ b/examples/src/static_gltf/mod.rs
@@ -49,7 +49,10 @@ struct StaticGltfExample {
 }
 
 impl rend3_framework::App for StaticGltfExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/static_gltf/mod.rs
+++ b/examples/src/static_gltf/mod.rs
@@ -142,7 +142,7 @@ impl rend3_framework::App for StaticGltfExample {
 
 pub fn main() {
     let app = StaticGltfExample::default();
-    rend3_framework::start(app, winit::window::WindowBuilder::new().with_title("gltf-example").with_maximized(true));
+    rend3_framework::start(app, winit::window::WindowAttributes::default().with_title("gltf-example").with_maximized(true));
 }
 
 #[cfg(test)]

--- a/examples/src/static_gltf/mod.rs
+++ b/examples/src/static_gltf/mod.rs
@@ -94,7 +94,7 @@ impl rend3_framework::App for StaticGltfExample {
         }));
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         // Swap the instruction buffers so that our frame's changes can be processed.
         context.renderer.swap_instruction_buffers();
         // Evaluate our frame's world-change instructions

--- a/examples/src/tests.rs
+++ b/examples/src/tests.rs
@@ -80,7 +80,9 @@ pub async fn test_app<A: App<T>, T: 'static>(mut config: TestConfiguration<A>) -
 
     let image = download_image(&renderer, texture, config.size).await.unwrap();
 
-    compare_image_to_path(&image, Path::new(config.reference_path), config.threshold_set).unwrap();
+    compare_image_to_path(&image, Path::new(config.reference_path), config.threshold_set)
+        .context(config.reference_path) // Location of reference image
+        .unwrap();
 
     Ok(())
 }

--- a/examples/src/textured_quad/mod.rs
+++ b/examples/src/textured_quad/mod.rs
@@ -123,7 +123,7 @@ impl rend3_framework::App for TexturedQuadExample {
         }
     }
 
-    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_, ()>) {
+    fn handle_redraw(&mut self, context: rend3_framework::RedrawContext<'_>) {
         // Swap the instruction buffers so that our frame's changes can be processed.
         context.renderer.swap_instruction_buffers();
         // Evaluate our frame's world-change instructions

--- a/examples/src/textured_quad/mod.rs
+++ b/examples/src/textured_quad/mod.rs
@@ -39,7 +39,11 @@ struct TexturedQuadExample {
     data: Option<TexturedQuadExampleData>,
 }
 impl rend3_framework::App for TexturedQuadExample {
-    const HANDEDNESS: rend3::types::Handedness = rend3::types::Handedness::Left;
+    /// Set handedness of coordinate system
+    fn get_handedness(&self) -> rend3::types::Handedness {
+        rend3::types::Handedness::Left    // default
+    }
+
 
     fn sample_count(&self) -> rend3::types::SampleCount {
         SAMPLE_COUNT

--- a/examples/src/textured_quad/mod.rs
+++ b/examples/src/textured_quad/mod.rs
@@ -172,7 +172,7 @@ impl rend3_framework::App for TexturedQuadExample {
 
 pub fn main() {
     let app = TexturedQuadExample::default();
-    rend3_framework::start(app, winit::window::WindowBuilder::new().with_title("textured-quad").with_maximized(true))
+    rend3_framework::start(app, winit::window::WindowAttributes::default().with_title("textured-quad").with_maximized(true))
 }
 
 #[cfg(test)]

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.20.0", path = "../rend3" }
-rend3-routine = { version = "^0.20", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.20", path = "../rend3-gltf" }
+rend3 = { version = "^0.22", path = "../rend3" }
+rend3-routine = { version = "^0.22", path = "../rend3-routine" }
+rend3-gltf = { version = "^0.22", path = "../rend3-gltf" }

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.22", path = "../rend3" }
-rend3-routine = { version = "^0.22", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.22", path = "../rend3-gltf" }
+rend3 = { version = "^0.22.1", path = "../rend3" }
+rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
+rend3-gltf = { version = "^0.22.1", path = "../rend3-gltf" }

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.3.0", path = "../rend3" }
-rend3-routine = { version = "^0.3.0", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.3.0", path = "../rend3-gltf" }
+rend3 = { version = "^0.20.0", path = "../rend3" }
+rend3-routine = { version = "^0.20", path = "../rend3-routine" }
+rend3-gltf = { version = "^0.20", path = "../rend3-gltf" }

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.23.0", path = "../rend3" }
-rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.23.0", path = "../rend3-gltf" }
+rend3 = { version = "^0.23.1", path = "../rend3" }
+rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
+rend3-gltf = { version = "^0.23.1", path = "../rend3-gltf" }

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.23.1", path = "../rend3" }
-rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.23.1", path = "../rend3-gltf" }
+rend3 = { path = "../rend3" }
+rend3-routine = { path = "../rend3-routine" }
+rend3-gltf = { path = "../rend3-gltf" }

--- a/rend3-anim/Cargo.toml
+++ b/rend3-anim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-anim"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Skeletal animation playback utilities for rend3 rendering library."
@@ -12,6 +12,6 @@ rust-version = "1.71"
 
 [dependencies]
 itertools = "0.12"
-rend3 = { version = "^0.22.1", path = "../rend3" }
-rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
-rend3-gltf = { version = "^0.22.1", path = "../rend3-gltf" }
+rend3 = { version = "^0.23.0", path = "../rend3" }
+rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
+rend3-gltf = { version = "^0.23.0", path = "../rend3-gltf" }

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.28"
 egui-wgpu = "0.28"
 glam = "0.25"
-rend3 = { version = "^0.22", path = "../rend3" }
-wgpu = "22.0"
+rend3 = { version = "^0.22.1", path = "../rend3" }
+wgpu = "22.1"
 wgpu-types = "22.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -13,8 +13,9 @@ rust-version = "1.71"
 
 [dependencies]
 egui = "0.30"
-egui-wgpu = "0.30"
-glam = "0.28"
+###### egui-wgpu = "0.30"
+# ***TEMP*** patch because Github and crates.io are out of sync
+egui-wgpu = { git = "https://github.com/emilk/egui.git", version = "0.30"  }
 rend3 = { path = "../rend3" }
 wgpu = { workspace = true }
 wgpu-types = { workspace = true }

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.28"
 egui-wgpu = "0.28"
 glam = "0.25"
-rend3 = { version = "^0.20", path = "../rend3" }
-wgpu = "0.20"
-wgpu-types = "0.20"
+rend3 = { version = "^0.22", path = "../rend3" }
+wgpu = "22.0"
+wgpu-types = "22.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["game-development", "graphics", "rendering", "rendering::engine", 
 rust-version = "1.71"
 
 [dependencies]
-egui = "0.26"
-egui-wgpu = "0.26"
+egui = "0.28"
+egui-wgpu = "0.28"
 glam = "0.25"
-rend3 = { version = "^0.3.0", path = "../rend3" }
-wgpu = "0.19.0"
-wgpu-types = "0.19.0"
+rend3 = { version = "^0.3", path = "../rend3" }
+wgpu = "0.20"
+wgpu-types = "0.20"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.30"
 egui-wgpu = "0.30"
 glam = "0.28"
-rend3 = { version = "^0.23.1", path = "../rend3" }
+rend3 = { path = "../rend3" }
 wgpu = "23.0"
 wgpu-types = "23.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -16,5 +16,5 @@ egui = "0.30"
 egui-wgpu = "0.30"
 glam = "0.28"
 rend3 = { path = "../rend3" }
-wgpu = "23.0"
-wgpu-types = "23.0"
+wgpu = { workspace = true }
+wgpu-types = { workspace = true }

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.71"
 [dependencies]
 egui = "0.28"
 egui-wgpu = "0.28"
-glam = "0.25"
+glam = "0.28"
 rend3 = { version = "^0.22.1", path = "../rend3" }
 wgpu = "22.1"
 wgpu-types = "22.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["game-development", "graphics", "rendering", "rendering::engine", 
 rust-version = "1.71"
 
 [dependencies]
-egui = "0.28"
-egui-wgpu = "0.28"
+egui = "0.29"
+egui-wgpu = "0.29"
 glam = "0.28"
 rend3 = { version = "^0.22.1", path = "../rend3" }
 wgpu = "22.1"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["game-development", "graphics", "rendering", "rendering::engine", 
 rust-version = "1.71"
 
 [dependencies]
-egui = "0.29"
-egui-wgpu = "0.29"
+egui = "0.30"
+egui-wgpu = "0.30"
 glam = "0.28"
 rend3 = { version = "^0.23.0", path = "../rend3" }
 wgpu = "23.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.30"
 egui-wgpu = "0.30"
 glam = "0.28"
-rend3 = { version = "^0.23.0", path = "../rend3" }
+rend3 = { version = "^0.23.1", path = "../rend3" }
 wgpu = "23.0"
 wgpu-types = "23.0"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.28"
 egui-wgpu = "0.28"
 glam = "0.25"
-rend3 = { version = "^0.3", path = "../rend3" }
+rend3 = { version = "^0.20", path = "../rend3" }
 wgpu = "0.20"
 wgpu-types = "0.20"

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -12,10 +12,9 @@ categories = ["game-development", "graphics", "rendering", "rendering::engine", 
 rust-version = "1.71"
 
 [dependencies]
-egui = "0.30"
-###### egui-wgpu = "0.30"
-# ***TEMP*** patch because Github and crates.io are out of sync
-egui-wgpu = { git = "https://github.com/emilk/egui.git", version = "0.30"  }
+egui = "0.31"
+egui-wgpu = "0.31"
 rend3 = { path = "../rend3" }
 wgpu = { workspace = true }
 wgpu-types = { workspace = true }
+glam = { workspace = true }

--- a/rend3-egui/Cargo.toml
+++ b/rend3-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-egui"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Egui Render Routine for the rend3 rendering library."
@@ -15,6 +15,6 @@ rust-version = "1.71"
 egui = "0.29"
 egui-wgpu = "0.29"
 glam = "0.28"
-rend3 = { version = "^0.22.1", path = "../rend3" }
-wgpu = "22.1"
-wgpu-types = "22.0"
+rend3 = { version = "^0.23.0", path = "../rend3" }
+wgpu = "23.0"
+wgpu-types = "23.0"

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -32,7 +32,8 @@ impl EguiRenderRoutine {
         height: u32,
         scale_factor: f32,
     ) -> Self {
-        let rpass = egui_wgpu::Renderer::new(&renderer.device, surface_format, None, samples as _);
+        const DITHERING: bool = false;  // new EGUI feature.
+        let rpass = egui_wgpu::Renderer::new(&renderer.device, surface_format, None, samples as _, DITHERING);
 
         Self {
             internal: rpass,

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -89,9 +89,7 @@ impl EguiRenderRoutine {
                 &self.screen_descriptor,
             );
             drop(cmd_buffer);
-
-            todo!(); // ***MUST FIX. WGPU CHANGE. SEE NOTES***
-            //////// ***TEMP TURNOFF*** self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
+            self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
         });
     }
 

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -90,6 +90,7 @@ impl EguiRenderRoutine {
             );
             drop(cmd_buffer);
 
+            todo!(); // ***MUST FIX. WGPU CHANGE. SEE NOTES***
             //////// ***TEMP TURNOFF*** self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
         });
     }

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -89,7 +89,7 @@ impl EguiRenderRoutine {
                 &self.screen_descriptor,
             );
             drop(cmd_buffer);
-            self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
+            self.internal.render(&mut rpass.borrow_mut(), input.clipped_meshes, &self.screen_descriptor);
         });
     }
 

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -90,7 +90,7 @@ impl EguiRenderRoutine {
             );
             drop(cmd_buffer);
 
-            self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
+            //////// ***TEMP TURNOFF*** self.internal.render(rpass, input.clipped_meshes, &self.screen_descriptor);
         });
     }
 

--- a/rend3-egui/src/lib.rs
+++ b/rend3-egui/src/lib.rs
@@ -142,14 +142,14 @@ impl EguiRenderRoutine {
         let texture_size = wgpu::Extent3d { width: dimensions.0, height: dimensions.1, depth_or_array_layers: 1 };
 
         queue.write_texture(
-            wgpu::ImageCopyTexture {
+            wgpu::TexelCopyTextureInfo {
                 texture: &image_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
             image_rgba,
-            wgpu::ImageDataLayout {
+            wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some((dimensions.0 / block_dimensions.0) * block_size),
                 rows_per_image: None,

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -23,7 +23,7 @@ rend3-routine = { version = "0.3.0", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.29.4", features = ["rwh_05"] }
-wgpu = "0.19.0"
+wgpu = "0.20.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -22,7 +22,7 @@ rend3 = { version = "0.22.1", path = "../rend3" }
 rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
-winit = { version = "0.29.4", features = ["rwh_05"] }
+winit = { version = "0.30", features = ["rwh_05"] }
 wgpu = "22.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -18,8 +18,8 @@ glam = "0.28"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.23.0", path = "../rend3" }
-rend3-routine = { version = "0.23.0", path = "../rend3-routine" }
+rend3 = { version = "0.23.1", path = "../rend3" }
+rend3-routine = { version = "0.23.1", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.30", features = ["rwh_05"] }

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -23,7 +23,7 @@ rend3-routine = { path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.30" }
-wgpu = "23.0"
+wgpu = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -18,12 +18,12 @@ glam = "0.28"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.22.0", path = "../rend3" }
-rend3-routine = { version = "0.22.0", path = "../rend3-routine" }
+rend3 = { version = "0.22.1", path = "../rend3" }
+rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.29.4", features = ["rwh_05"] }
-wgpu = "0.20.0"
+wgpu = "0.20.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -22,7 +22,7 @@ rend3 = { version = "0.23.1", path = "../rend3" }
 rend3-routine = { version = "0.23.1", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
-winit = { version = "0.30", features = ["rwh_05"] }
+winit = { version = "0.30" }
 wgpu = "23.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -23,7 +23,7 @@ rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.29.4", features = ["rwh_05"] }
-wgpu = "0.20.1"
+wgpu = "22.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -18,12 +18,12 @@ glam = "0.28"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.22.1", path = "../rend3" }
-rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
+rend3 = { version = "0.23.0", path = "../rend3" }
+rend3-routine = { version = "0.23.0", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.30", features = ["rwh_05"] }
-wgpu = "22.1"
+wgpu = "23.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # logging

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -14,12 +14,12 @@ rust-version = "1.71"
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-glam = "0.25"
+glam = "0.28"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.20.0", path = "../rend3" }
-rend3-routine = { version = "0.20.0", path = "../rend3-routine" }
+rend3 = { version = "0.22.0", path = "../rend3" }
+rend3-routine = { version = "0.22.0", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.29.4", features = ["rwh_05"] }

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -18,8 +18,8 @@ glam = "0.25"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.3.0", path = "../rend3" }
-rend3-routine = { version = "0.3.0", path = "../rend3-routine" }
+rend3 = { version = "0.20.0", path = "../rend3" }
+rend3-routine = { version = "0.20.0", path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.29.4", features = ["rwh_05"] }

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.71"
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-glam = "0.28"
+glam = { workspace = true }
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }

--- a/rend3-framework/Cargo.toml
+++ b/rend3-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-framework"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Simple framework for making applications with the rend3 rendering library."
@@ -18,8 +18,8 @@ glam = "0.28"
 log = "0.4"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-rend3 = { version = "0.23.1", path = "../rend3" }
-rend3-routine = { version = "0.23.1", path = "../rend3-routine" }
+rend3 = { path = "../rend3" }
+rend3-routine = { path = "../rend3-routine" }
 thiserror = { version = "1" }
 web-time = "1.1"
 winit = { version = "0.30" }

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -65,7 +65,7 @@ pub struct RedrawContext<'a> {
 
 pub trait App<T: 'static = ()> {
     /// The handedness of the coordinate system of the renderer.
-    const HANDEDNESS: Handedness;
+    //////const HANDEDNESS: Handedness;
 
     fn register_logger(&mut self) {
         #[cfg(target_arch = "wasm32")]
@@ -304,7 +304,7 @@ impl <T> ApplicationHandler<T> for Rend3ApplicationHandler<'_> {
                         control_flow = c;
                         self.last_user_control_mode = c;
                     },
-                    event_loop,
+                    event_loop_window_target: event_loop,
                 },
                 event,
             );

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -16,6 +16,7 @@ use winit::{
     window::{Window, WindowAttributes, WindowId},
     application::ApplicationHandler,
 };
+use pollster::FutureExt;
 
 mod assets;
 mod grab;
@@ -207,7 +208,7 @@ struct Rend3ApplicationHandler<'a, T>{
 
 impl <T: App> Rend3ApplicationHandler<'_, T> {
     /// Usual new
-    pub fn new(app: T, window_attributes: WindowAttributes) -> Self {
+    pub fn new(mut app: T, window_attributes: WindowAttributes) -> Self {
         app.register_logger();
         app.register_panic_hook();
 
@@ -216,7 +217,11 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
         let window = Arc::new(window);
         let window_size = window.inner_size();
 
-        let iad = app.create_iad().await.unwrap();
+        //////let iad = app.create_iad().await.unwrap();
+        
+        let iad = async {
+            app.create_iad().await.unwrap()
+        }.block_on();
 
         // The one line of unsafe needed. We just need to guarentee that the window
         // outlives the use of the surface.
@@ -297,7 +302,7 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
             present_mode: app.present_mode(),
             requires_reconfigure: true,
         };
-
+/*
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "wasm32")] {
                 use winit::platform::web::EventLoopExtWebSys;
@@ -306,6 +311,7 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
             let event_loop_function = EventLoop::run;
             }
         }
+*/
         let mut previous_time = web_time::Instant::now();
         Self {
             app, 

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -338,7 +338,7 @@ impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
 /// New Winit framework usage
 //  ***NEED MORE CALLBACK FNS*** device_event, etc.
 //////type AppRef<'a> = &'a mut dyn App;
-impl<T: 'static> ApplicationHandler for Rend3ApplicationHandler<'_,T> {
+impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
     /// Resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         todo!();        // what do we do here?
@@ -450,11 +450,10 @@ impl<T: 'static> ApplicationHandler for Rend3ApplicationHandler<'_,T> {
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
         todo!();
     }
-/* ***TEMP*** type parameter to this needs work.    
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
         todo!();
     }
-*/
+
     /// Device event. Winit fans these out, we put them back together, Rend3 framework fans them out.
     fn device_event(
         &mut self,

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -531,11 +531,11 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
         self.pass_through_event(event_loop, event);    // pass up to Rend3 level
     }
 }
-
+/*
 /// Old async start. This has the event loop.
 /// It's only really async on mobile.
 /// On other platforms it's blocked immediately on return.
-pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_attributes: WindowAttributes) {
+pub async fn async_start_old<A: App<T> + 'static, T: 'static>(mut app: A, window_attributes: WindowAttributes) {
     app.register_logger();
     app.register_panic_hook();
 
@@ -741,11 +741,12 @@ pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_att
         },
     );
 }
+*/
 
 /// New async start. This has the event loop.
 /// It's only really async on mobile.
 /// On other platforms it's blocked immediately on return.
-pub async fn async_start_new<A: App<T> + 'static, T: 'static>(mut app: A, window_attributes: WindowAttributes) {
+pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_attributes: WindowAttributes) {
     //  Setup phase
     let (mut application_handler, event_loop) = Rend3ApplicationHandler::new(&mut app, window_attributes);
     // Run the application
@@ -805,7 +806,6 @@ fn handle_surface<A: App<T>  + ?Sized, T: 'static>(
 }
 
 pub fn start<A: App<T> + 'static, T: 'static>(app: A, window_attributes: WindowAttributes) {
-    const USE_APP_FORM: bool = true; // ***TEMP*** testing new form
     #[cfg(target_arch = "wasm32")]
     {
         wasm_bindgen_futures::spawn_local(async_start(app, window_attributes));
@@ -813,10 +813,7 @@ pub fn start<A: App<T> + 'static, T: 'static>(app: A, window_attributes: WindowA
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        if USE_APP_FORM {
-            pollster::block_on(async_start_new(app, window_attributes));
-        } else {   
-            pollster::block_on(async_start_new(app, window_attributes));
-        }
+        
+        pollster::block_on(async_start(app, window_attributes));
     }
 }

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -554,12 +554,18 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
         todo!();
     }
     
+    /// Exiting - pass through to Rend3 level
     fn exiting(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();
+        let event = Event::LoopExiting{ };  // have to construct outer event for existing functions
+        let mut control_flow = event_loop.control_flow();
+        self.pass_through_event(event_loop, event);    // pass up to Rend3 level
     }
     
+    /// Memory warning - pass through to Rend3 level
     fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();
+        let event = Event::MemoryWarning{ };  // have to construct outer event for existing functions
+        let mut control_flow = event_loop.control_flow();
+        self.pass_through_event(event_loop, event);    // pass up to Rend3 level
     }
 }
 

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -163,10 +163,8 @@ pub trait App<T: 'static = ()> {
     
     /// Left handed or right handed coordinate system?
     /// Trait implementation can override.
-    /// Left handed by default.
-    fn get_handedness(&self) -> Handedness{
-        Handedness::Left    // default
-    }
+    /// Must be overridden.
+    fn get_handedness(&self) -> Handedness;
 }
 
 pub fn lock<T>(lock: &parking_lot::Mutex<T>) -> parking_lot::MutexGuard<'_, T> {

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -11,7 +11,7 @@ use rend3_routine::base::BaseRenderGraph;
 use wgpu::{Instance, PresentMode, SurfaceError};
 use winit::{
     error::EventLoopError,
-    event::{Event, WindowEvent},
+    event::{Event, WindowEvent, StartCause, DeviceEvent, DeviceId},
     event_loop::{ControlFlow, EventLoop, ActiveEventLoop},
     window::{Window, WindowAttributes, WindowId},
     application::ApplicationHandler,
@@ -443,6 +443,42 @@ impl ApplicationHandler<AppRef<'static>> for Rend3ApplicationHandler<'_, AppRef<
                 event,
             );
         }
+    }
+    
+    // Provided methods
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
+        todo!();
+    }
+/* ***TEMP*** type parameter to this needs work.    
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
+        todo!();
+    }
+*/
+    
+    fn device_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        todo!();
+    }
+    
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        todo!();
+    }
+    
+    
+    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        todo!();
+    }
+    
+    fn exiting(&mut self, event_loop: &ActiveEventLoop) {
+        todo!();
+    }
+    
+    fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
+        todo!();
     }
 }
 

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -160,6 +160,13 @@ pub trait App<T: 'static = ()> {
     fn handle_redraw_done(&mut self, window: &Window) {
         window.request_redraw(); // just queue a redraw.
     }
+    
+    /// Left handed or right handed coordinate system?
+    /// Trait implementation can override.
+    /// Left handed by default.
+    fn get_handedness(&self) -> Handedness{
+        Handedness::Left    // default
+    }
 }
 
 pub fn lock<T>(lock: &parking_lot::Mutex<T>) -> parking_lot::MutexGuard<'_, T> {
@@ -234,10 +241,9 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
             Some(Arc::new(iad.instance.create_surface(window.clone()).unwrap()))
         };
 
-        const HANDEDNESS: Handedness = Handedness::Left;    // ***TEMP TEST*** needs to be a parameter
         // Make us a renderer.
         let renderer =
-            rend3::Renderer::new(iad.clone(), HANDEDNESS, Some(window_size.width as f32 / window_size.height as f32))
+            rend3::Renderer::new(iad.clone(), app.get_handedness(), Some(window_size.width as f32 / window_size.height as f32))
                 .unwrap();
 
         // Get the preferred format for the surface.

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -377,6 +377,11 @@ impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
 
 /// New Winit framework usage
 impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
+
+    /// Suspended
+    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        todo!();
+    }
     /// Resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         return; ///// todo!();        // what do we do here?
@@ -547,11 +552,6 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
                 event,
             );
 */
-    }
-    
-    
-    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();
     }
     
     /// Exiting - pass through to Rend3 level

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -183,9 +183,9 @@ pub struct DefaultRoutines {
 }
 
 /// Inner framework, required by winit's desire to become a framework.
-struct Rend3ApplicationHandler<'a, T>{
+struct Rend3ApplicationHandler<'a, T: 'static>{
     /// The Rend3 framework "app", reference
-    app: T,
+    app: &'a mut dyn App<T>,
     ///  The "window"
     window: Arc<winit::window::Window>,
     /// Instance Adapter Device
@@ -211,9 +211,10 @@ struct Rend3ApplicationHandler<'a, T>{
 
 }
 
-impl <T: App> Rend3ApplicationHandler<'_, T> {
+impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
     /// Usual new
-    pub fn new(mut app: T, window_attributes: WindowAttributes) -> Self {
+    //////pub fn new(app: &mut dyn App<T>, window_attributes: WindowAttributes) -> Self {
+    pub fn new(app: &'a mut dyn App<T>, window_attributes: WindowAttributes) -> Self {
         app.register_logger();
         app.register_panic_hook();
 
@@ -336,8 +337,8 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
 
 /// New Winit framework usage
 //  ***NEED MORE CALLBACK FNS*** device_event, etc.
-type AppRef<'a> = &'a mut dyn App;
-impl ApplicationHandler<AppRef<'static>> for Rend3ApplicationHandler<'_, AppRef<'_>> {
+//////type AppRef<'a> = &'a mut dyn App;
+impl<T: 'static> ApplicationHandler for Rend3ApplicationHandler<'_,T> {
     /// Resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         todo!();        // what do we do here?

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -218,7 +218,7 @@ impl <T: App> Rend3ApplicationHandler<'_, T> {
         let window_size = window.inner_size();
 
         //////let iad = app.create_iad().await.unwrap();
-        
+        //  This is silly, but, for some reason, create_iad is async.
         let iad = async {
             app.create_iad().await.unwrap()
         }.block_on();

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -346,7 +346,7 @@ impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
 impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
     /// Resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();        // what do we do here?
+        return; ///// todo!();        // what do we do here?
     }
     
     /// Window event received
@@ -453,7 +453,7 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
     
     // Provided methods
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
-        todo!();
+        return; ///// todo!();
     }
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
         todo!();
@@ -997,6 +997,7 @@ fn handle_surface<A: App<T>  + ?Sized, T: 'static>(
 }
 
 pub fn start<A: App<T> + 'static, T: 'static>(app: A, window_attributes: WindowAttributes) {
+    const USE_APP_FORM: bool = true; // ***TEMP*** testing new form
     #[cfg(target_arch = "wasm32")]
     {
         wasm_bindgen_futures::spawn_local(async_start(app, window_attributes));
@@ -1004,6 +1005,10 @@ pub fn start<A: App<T> + 'static, T: 'static>(app: A, window_attributes: WindowA
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        pollster::block_on(async_start(app, window_attributes));
+        if USE_APP_FORM {
+            pollster::block_on(async_start_new(app, window_attributes));
+        } else {   
+            pollster::block_on(async_start_new(app, window_attributes));
+        }
     }
 }

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -12,7 +12,7 @@ use wgpu::{Instance, PresentMode, SurfaceError};
 use winit::{
     error::EventLoopError,
     event::Event,
-    event_loop::{ControlFlow, EventLoop, EventLoopBuilder, ActiveEventLoop},
+    event_loop::{ControlFlow, EventLoop, ActiveEventLoop},
     window::{Window, WindowAttributes},
 };
 

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -159,9 +159,6 @@ pub trait App<T: 'static = ()> {
     fn handle_redraw_done(&mut self, window: &Window) {
         window.request_redraw(); // just queue a redraw.
     }
-    
-    /// Get handedness. Can't put a constant in a trait.
-    fn get_handedness(&self) -> Handedness;
 }
 
 pub fn lock<T>(lock: &parking_lot::Mutex<T>) -> parking_lot::MutexGuard<'_, T> {
@@ -195,8 +192,6 @@ struct Rend3ApplicationHandler<'a, T>{
     routines: &'a Arc<DefaultRoutines>,
     /// Base rendergraph
     base_rendergraph: &'a BaseRenderGraph,
-    /// Left-handed or right-handed coordinate system?
-    handedness: Handedness,
     /// Computer is suspended - don't draw
     suspended: bool,
     /// Renderer ref
@@ -344,9 +339,10 @@ pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_att
         Some(Arc::new(iad.instance.create_surface(window.clone()).unwrap()))
     };
 
+    const HANDEDNESS: Handedness = Handedness::Left;    // ***TEMP TEST*** needs to be a parameter
     // Make us a renderer.
     let renderer =
-        rend3::Renderer::new(iad.clone(), app.get_handedness(), Some(window_size.width as f32 / window_size.height as f32))
+        rend3::Renderer::new(iad.clone(), HANDEDNESS, Some(window_size.width as f32 / window_size.height as f32))
             .unwrap();
 
     // Get the preferred format for the surface.

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -149,7 +149,14 @@ pub trait App<T: 'static = ()> {
     /// "This is a useful place to put code that should be done before
     /// you start processing events" - Winit
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
-        //  default is nothing, can be overridden.
+        //  default is ignore, can be overridden.
+    }
+    
+    /// Winit-level user event.
+    /// New feature allows putting program-generated events on the main event queue.
+    /// Can be overridden by the application if desired.
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
+        //  Default is ignore
     }
 
     /// Handle a non-redraw event.
@@ -378,11 +385,11 @@ impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
 /// New Winit framework usage
 impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
 
-    /// Suspended
+    /// Program suspended
     fn suspended(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();
+        todo!();                        // what do we do here?
     }
-    /// Resumed after suspend
+    /// Program resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         return; ///// todo!();        // what do we do here?
     }
@@ -472,33 +479,19 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
         } else {
             let event = Event::WindowEvent { window_id, event: window_event };  // have to construct outer event for existing functions
             self.pass_through_event(event_loop, event);    // pass up to Rend3 level
-/*
-            self.app.handle_event(
-                EventContext {
-                    window: Some(&self.window),
-                    renderer: &self.renderer,
-                    routines: &self.routines,
-                    base_rendergraph: &self.base_rendergraph,
-                    resolution: self.stored_surface_info.size,
-                    control_flow: &mut |c: ControlFlow| {
-                        control_flow = c;
-                        self.last_user_control_mode = c;
-                    },
-                    event_loop_window_target: event_loop,
-                },
-                event,
-            );
-*/
         }
     }
     
     // Provided methods
+    /// Called on every event, before other processing.
+    /// Usually not used.
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
         self.app.new_events(event_loop, cause);
-        ////return; ///// todo!();
     }
+    
+    /// Winit-level user event. Allows putting events on event queue.
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
-        todo!();
+        self.app.user_event(event_loop, event);
     }
     
     /// Device event. Winit fans these out, we put them back together, Rend3 framework fans them out.
@@ -511,23 +504,6 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
         let event = Event::DeviceEvent { device_id, event };  // have to construct outer event for existing functions
         let mut control_flow = event_loop.control_flow();
         self.pass_through_event(event_loop, event);    // pass up to Rend3 level
-/*
-        self.app.handle_event(
-                EventContext {
-                    window: Some(&self.window),
-                    renderer: &self.renderer,
-                    routines: &self.routines,
-                    base_rendergraph: &self.base_rendergraph,
-                    resolution: self.stored_surface_info.size,
-                    control_flow: &mut |c: ControlFlow| {
-                        control_flow = c;
-                        self.last_user_control_mode = c;
-                    },
-                    event_loop_window_target: event_loop,
-                },
-                event,
-            );
-*/
     }
     
     /// About to wait event. Pass to common fn.
@@ -535,23 +511,6 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
         let event = Event::AboutToWait{ };  // have to construct outer event for existing functions
         let mut control_flow = event_loop.control_flow();
         self.pass_through_event(event_loop, event);    // pass up to Rend3 level
-/*
-        self.app.handle_event(
-                EventContext {
-                    window: Some(&self.window),
-                    renderer: &self.renderer,
-                    routines: &self.routines,
-                    base_rendergraph: &self.base_rendergraph,
-                    resolution: self.stored_surface_info.size,
-                    control_flow: &mut |c: ControlFlow| {
-                        control_flow = c;
-                        self.last_user_control_mode = c;
-                    },
-                    event_loop_window_target: event_loop,
-                },
-                event,
-            );
-*/
     }
     
     /// Exiting - pass through to Rend3 level
@@ -786,211 +745,6 @@ pub async fn async_start_new<A: App<T> + 'static, T: 'static>(mut app: A, window
     let (mut application_handler, mut event_loop) = Rend3ApplicationHandler::new(&mut app, window_attributes);
     // Run the application
     application_handler.run(event_loop);
-/*
-    app.register_logger();
-    app.register_panic_hook();
-
-    // Create the window invisible until we are rendering
-    let (event_loop, window) = app.create_window(window_attributes.with_visible(false)).unwrap();
-    let window = Arc::new(window);
-    let window_size = window.inner_size();
-
-    let iad = app.create_iad().await.unwrap();
-
-    // The one line of unsafe needed. We just need to guarentee that the window
-    // outlives the use of the surface.
-    //
-    // Android has to defer the surface until `Resumed` is fired. This doesn't fire
-    // on other platforms though :|
-    let mut surface = if cfg!(target_os = "android") {
-        None
-    } else {
-        Some(Arc::new(iad.instance.create_surface(window.clone()).unwrap()))
-    };
-
-    // Make us a renderer.
-    let renderer =
-        rend3::Renderer::new(iad.clone(), app.get_handedness(), Some(window_size.width as f32 / window_size.height as f32))
-            .unwrap();
-
-    // Get the preferred format for the surface.
-    //
-    // Assume android supports Rgba8Srgb, as it has 100% device coverage
-    let format = surface.as_ref().map_or(TextureFormat::Rgba8UnormSrgb, |s| {
-        let caps = s.get_capabilities(&iad.adapter);
-        let format = caps.formats[0];
-
-        // Configure the surface to be ready for rendering.
-        rend3::configure_surface(
-            s,
-            &iad.device,
-            format,
-            glam::UVec2::new(window_size.width, window_size.height),
-            rend3::types::PresentMode::Fifo,
-        );
-
-        format
-    });
-
-    let mut spp = rend3::ShaderPreProcessor::new();
-    rend3_routine::builtin_shaders(&mut spp);
-
-    let base_rendergraph = app.create_base_rendergraph(&renderer, &spp);
-    let mut data_core = renderer.data_core.lock();
-    let routines = Arc::new(DefaultRoutines {
-        pbr: Mutex::new(rend3_routine::pbr::PbrRoutine::new(
-            &renderer,
-            &mut data_core,
-            &spp,
-            &base_rendergraph.interfaces,
-        )),
-        skybox: Mutex::new(rend3_routine::skybox::SkyboxRoutine::new(&renderer, &spp, &base_rendergraph.interfaces)),
-        tonemapping: Mutex::new(rend3_routine::tonemapping::TonemappingRoutine::new(
-            &renderer,
-            &spp,
-            &base_rendergraph.interfaces,
-            format,
-        )),
-    });
-    drop(data_core);
-
-    app.setup(SetupContext {
-        windowing: Some(WindowingSetup { event_loop: &event_loop, window: &window }),
-        renderer: &renderer,
-        routines: &routines,
-        surface_format: format,
-        resolution: UVec2::new(window_size.width, window_size.height),
-        scale_factor: window.scale_factor() as f32,
-    });
-
-    // We're ready, so lets make things visible
-    window.set_visible(true);
-
-    let mut suspended = cfg!(target_os = "android");
-    let mut last_user_control_mode = ControlFlow::Wait;
-    let mut stored_surface_info = StoredSurfaceInfo {
-        size: glam::UVec2::new(window_size.width, window_size.height),
-        scale_factor: app.scale_factor(),
-        sample_count: app.sample_count(),
-        present_mode: app.present_mode(),
-        requires_reconfigure: true,
-    };
-
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "wasm32")] {
-            use winit::platform::web::EventLoopExtWebSys;
-            let event_loop_function = EventLoop::spawn;
-        } else {
-            let event_loop_function = EventLoop::run;
-        }
-    }
-
-    let mut previous_time = web_time::Instant::now();
-
-    // On native this is a result, but on wasm it's a unit type.
-    #[allow(clippy::let_unit_value)]
-    let _ = (event_loop_function)(
-        event_loop,
-        move |event: Event<T>, event_loop_window_target: &ActiveEventLoop| {
-            let mut control_flow = event_loop_window_target.control_flow();
-            if let Some(suspend) =
-                handle_surface(&app, &window, &event, &iad.instance, &mut surface, &renderer, &mut stored_surface_info)
-            {
-                suspended = suspend;
-            }
-
-            // We move to Wait when we get suspended so we don't spin at 50k FPS.
-            match event {
-                Event::Suspended => {
-                    control_flow = ControlFlow::Wait;
-                }
-                Event::Resumed => {
-                    control_flow = last_user_control_mode;
-                }
-                _ => {}
-            }
-
-            // Close button was clicked, we should close.
-            if let winit::event::Event::WindowEvent { event: winit::event::WindowEvent::CloseRequested, .. } = event {
-                event_loop_window_target.exit();
-                return;
-            }
-
-            // We need to block all updates
-            if let Event::WindowEvent { window_id: _, event: winit::event::WindowEvent::RedrawRequested } = event {
-                if suspended {
-                    return;
-                }
-
-                let Some(surface) = surface.as_ref() else {
-                    return;
-                };
-
-                if stored_surface_info.requires_reconfigure {
-                    rend3::configure_surface(
-                        surface,
-                        &renderer.device,
-                        format,
-                        stored_surface_info.size,
-                        stored_surface_info.present_mode,
-                    );
-                    stored_surface_info.requires_reconfigure = false;
-                }
-
-                let surface_texture = match surface.get_current_texture() {
-                    Ok(texture) => texture,
-                    Err(SurfaceError::Outdated) => {
-                        stored_surface_info.requires_reconfigure = true;
-                        return;
-                    }
-                    Err(SurfaceError::Timeout) => {
-                        return;
-                    }
-                    Err(SurfaceError::OutOfMemory | SurfaceError::Lost) => panic!("Surface OOM"),
-                };
-
-                let current_time = web_time::Instant::now();
-                let delta_t_seconds = (current_time - previous_time).as_secs_f32();
-                previous_time = current_time;
-
-                app.handle_redraw(RedrawContext {
-                    window: Some(&window),
-                    renderer: &renderer,
-                    routines: &routines,
-                    base_rendergraph: &base_rendergraph,
-                    surface_texture: &surface_texture.texture,
-                    resolution: stored_surface_info.size,
-                    control_flow: &mut |c: ControlFlow| {
-                        control_flow = c;
-                        last_user_control_mode = c;
-                    },
-                    event_loop_window_target: Some(event_loop_window_target),
-                    delta_t_seconds,
-                });
-
-                surface_texture.present();
-
-                app.handle_redraw_done(&window); // standard action is to redraw, but that can be overridden.
-            } else {
-                app.handle_event(
-                    EventContext {
-                        window: Some(&window),
-                        renderer: &renderer,
-                        routines: &routines,
-                        base_rendergraph: &base_rendergraph,
-                        resolution: stored_surface_info.size,
-                        control_flow: &mut |c: ControlFlow| {
-                            control_flow = c;
-                            last_user_control_mode = c;
-                        },
-                        event_loop_window_target,
-                    },
-                    event,
-                );
-            }
-        },
-    );
-*/
 }
 
 

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -454,18 +454,51 @@ impl ApplicationHandler<AppRef<'static>> for Rend3ApplicationHandler<'_, AppRef<
         todo!();
     }
 */
-    
+    /// Device event. Winit fans these out, we put them back together, Rend3 framework fans them out.
     fn device_event(
         &mut self,
         event_loop: &ActiveEventLoop,
         device_id: DeviceId,
         event: DeviceEvent,
     ) {
-        todo!();
+        let event = Event::DeviceEvent { device_id, event };  // have to construct outer event for existing functions
+        let mut control_flow = event_loop.control_flow();
+        self.app.handle_event(
+                EventContext {
+                    window: Some(&self.window),
+                    renderer: &self.renderer,
+                    routines: &self.routines,
+                    base_rendergraph: &self.base_rendergraph,
+                    resolution: self.stored_surface_info.size,
+                    control_flow: &mut |c: ControlFlow| {
+                        control_flow = c;
+                        self.last_user_control_mode = c;
+                    },
+                    event_loop_window_target: event_loop,
+                },
+                event,
+            );
     }
     
+    /// About to wait event. Pass to common fn.
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        todo!();
+        let event = Event::AboutToWait{ };  // have to construct outer event for existing functions
+        let mut control_flow = event_loop.control_flow();
+        self.app.handle_event(
+                EventContext {
+                    window: Some(&self.window),
+                    renderer: &self.renderer,
+                    routines: &self.routines,
+                    base_rendergraph: &self.base_rendergraph,
+                    resolution: self.stored_surface_info.size,
+                    control_flow: &mut |c: ControlFlow| {
+                        control_flow = c;
+                        self.last_user_control_mode = c;
+                    },
+                    event_loop_window_target: event_loop,
+                },
+                event,
+            );
     }
     
     

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -159,6 +159,9 @@ pub trait App<T: 'static = ()> {
     fn handle_redraw_done(&mut self, window: &Window) {
         window.request_redraw(); // just queue a redraw.
     }
+    
+    /// Get handedness. Can't put a constant in a trait.
+    fn get_handedness(&self) -> Handedness;
 }
 
 pub fn lock<T>(lock: &parking_lot::Mutex<T>) -> parking_lot::MutexGuard<'_, T> {
@@ -192,6 +195,8 @@ struct Rend3ApplicationHandler<'a, T>{
     routines: &'a Arc<DefaultRoutines>,
     /// Base rendergraph
     base_rendergraph: &'a BaseRenderGraph,
+    /// Left-handed or right-handed coordinate system?
+    handedness: Handedness,
     /// Computer is suspended - don't draw
     suspended: bool,
     /// Renderer ref
@@ -341,7 +346,7 @@ pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_att
 
     // Make us a renderer.
     let renderer =
-        rend3::Renderer::new(iad.clone(), A::HANDEDNESS, Some(window_size.width as f32 / window_size.height as f32))
+        rend3::Renderer::new(iad.clone(), app.get_handedness(), Some(window_size.width as f32 / window_size.height as f32))
             .unwrap();
 
     // Get the preferred format for the surface.

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -461,6 +461,7 @@ impl<T: 'static> ApplicationHandler<T> for Rend3ApplicationHandler<'_,T> {
                     return;
                 }
                 Err(SurfaceError::OutOfMemory | SurfaceError::Lost) => panic!("Surface OOM"),
+                Err(wgpu::SurfaceError::Other) => todo!(), // ***FIX** new case                
             };
             let current_time = web_time::Instant::now();
             let delta_t_seconds = (current_time - self.previous_time).as_secs_f32();
@@ -695,6 +696,7 @@ pub async fn async_start<A: App<T> + 'static, T: 'static>(mut app: A, window_att
                         return;
                     }
                     Err(SurfaceError::OutOfMemory | SurfaceError::Lost) => panic!("Surface OOM"),
+                    Err(wgpu::SurfaceError::Other) => todo!(), // ***FIX*** new case
                 };
 
                 let current_time = web_time::Instant::now();

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -208,7 +208,7 @@ struct Rend3ApplicationHandler<'a, T>{
 /// New Winit framework usage
 //  ***NEED MORE CALLBACK FNS*** device_event, etc.
 type AppRef<'a> = &'a mut dyn App;
-impl ApplicationHandler<dyn App> for Rend3ApplicationHandler<'_, AppRef<'_>> {
+impl ApplicationHandler<AppRef<'static>> for Rend3ApplicationHandler<'_, AppRef<'_>> {
     /// Resumed after suspend
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         todo!();        // what do we do here?

--- a/rend3-framework/src/lib.rs
+++ b/rend3-framework/src/lib.rs
@@ -66,7 +66,6 @@ pub struct RedrawContext<'a> {
 
 pub trait App<T: 'static = ()> {
     /// The handedness of the coordinate system of the renderer.
-    //////const HANDEDNESS: Handedness;
 
     fn register_logger(&mut self) {
         #[cfg(target_arch = "wasm32")]
@@ -90,7 +89,6 @@ pub trait App<T: 'static = ()> {
         profiling::scope!("creating window");
 
         let event_loop = EventLoop::with_user_event().build()?;
-        //////let window = builder.build(&event_loop).expect("Could not build window");
         let window = event_loop.create_window(window_attributes).expect("Could not build window"); // (JN) for winit 0.30
 
         #[cfg(target_arch = "wasm32")]
@@ -237,7 +235,6 @@ impl <'a, T: 'static> Rend3ApplicationHandler<'a, T> {
         let window = Arc::new(window);
         let window_size = window.inner_size();
 
-        //////let iad = app.create_iad().await.unwrap();
         //  This is silly, but, for some reason, create_iad is async.
         let iad = async {
             app.create_iad().await.unwrap()

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -26,8 +26,8 @@ image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.22.1", path = "../rend3" }
-rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
+rend3 = { version = "^0.23.0", path = "../rend3" }
+rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -26,8 +26,8 @@ image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.23.0", path = "../rend3" }
-rend3-routine = { version = "^0.23.0", path = "../rend3-routine" }
+rend3 = { version = "^0.23.1", path = "../rend3" }
+rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.22"
 bytemuck = "1"
 ddsfile = { version = "0.5", optional = true }
 float-ord = "0.3.2"
-glam = "0.28"
+glam = { workspace = true }
 gltf = { version = "1.0", default-features = false, features = ["KHR_lights_punctual", "KHR_texture_transform", "KHR_materials_unlit", "extras", "names", "utils"] }
 image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -26,8 +26,8 @@ image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.23.1", path = "../rend3" }
-rend3-routine = { version = "^0.23.1", path = "../rend3-routine" }
+rend3 = { path = "../rend3" }
+rend3-routine = { path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -20,14 +20,14 @@ base64 = "0.22"
 bytemuck = "1"
 ddsfile = { version = "0.5", optional = true }
 float-ord = "0.3.2"
-glam = "0.25"
+glam = "0.28"
 gltf = { version = "1.0", default-features = false, features = ["KHR_lights_punctual", "KHR_texture_transform", "KHR_materials_unlit", "extras", "names", "utils"] }
 image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.20.0", path = "../rend3" }
-rend3-routine = { version = "^0.20.0", path = "../rend3-routine" }
+rend3 = { version = "^0.22.0", path = "../rend3" }
+rend3-routine = { version = "^0.22.0", path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -22,7 +22,7 @@ ddsfile = { version = "0.5", optional = true }
 float-ord = "0.3.2"
 glam = "0.25"
 gltf = { version = "1.0", default-features = false, features = ["KHR_lights_punctual", "KHR_texture_transform", "KHR_materials_unlit", "extras", "names", "utils"] }
-image = { version = "0.24", default-features = false }
+image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -26,8 +26,8 @@ image = { version = "0.25", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.22.0", path = "../rend3" }
-rend3-routine = { version = "^0.22.0", path = "../rend3-routine" }
+rend3 = { version = "^0.22.1", path = "../rend3" }
+rend3-routine = { version = "^0.22.1", path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/Cargo.toml
+++ b/rend3-gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-gltf"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "gltf scene and model loader for the rend3 rendering library."
@@ -26,8 +26,8 @@ image = { version = "0.24", default-features = false }
 ktx2 = { version = "0.3", optional = true }
 log = "0.4"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.3.0", path = "../rend3" }
-rend3-routine = { version = "^0.3.0", path = "../rend3-routine" }
+rend3 = { version = "^0.20.0", path = "../rend3" }
+rend3-routine = { version = "^0.20.0", path = "../rend3-routine" }
 rustc-hash = "1"
 thiserror = "1"
 

--- a/rend3-gltf/src/lib.rs
+++ b/rend3-gltf/src/lib.rs
@@ -1290,7 +1290,7 @@ pub mod util {
             | k2F::R64G64B64A64_UINT
             | k2F::R64G64B64A64_SINT
             | k2F::R64G64B64A64_SFLOAT => return None,
-            k2F::B10G11R11_UFLOAT_PACK32 => r3F::Rg11b10Float,
+            k2F::B10G11R11_UFLOAT_PACK32 => r3F::Rg11b10Ufloat,
             k2F::E5B9G9R9_UFLOAT_PACK32 => r3F::Rgb9e5Ufloat,
             k2F::D16_UNORM => return None,
             k2F::X8_D24_UNORM_PACK32 => r3F::Depth24Plus,
@@ -1514,7 +1514,7 @@ pub mod util {
             | d3F::R10G10B10A2_Typeless
             | d3F::R10G10B10A2_UNorm
             | d3F::R10G10B10A2_UInt => return None,
-            d3F::R11G11B10_Float => r3F::Rg11b10Float,
+            d3F::R11G11B10_Float => r3F::Rg11b10Ufloat,
             d3F::R8G8B8A8_Typeless | d3F::R8G8B8A8_UNorm | d3F::R8G8B8A8_UNorm_sRGB => {
                 if srgb {
                     r3F::Rgba8UnormSrgb

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -20,7 +20,7 @@ encase = { version = "0.7", features = ["glam"] }
 flume = "0.11"
 glam = { version = "0.25.0", features = ["bytemuck"] }
 log = "0.4"
-naga = { version = "0.19.0", features = ["wgsl-in"] }
+naga = { version = "0.20.0", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."
@@ -24,7 +24,7 @@ naga = { version = "22.1", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.23.0", path = "../rend3" }
+rend3 = { path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -29,4 +29,4 @@ rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wgpu = "23.0"
-wgpu-profiler = "0.18"
+wgpu-profiler = "0.19"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."
@@ -24,7 +24,7 @@ naga = { version = "0.20.0", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.22.0", path = "../rend3" }
+rend3 = { version = "^0.22.1", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -28,5 +28,5 @@ rend3 = { path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wgpu = "23.0"
-wgpu-profiler = "0.19"
+wgpu = { workspace = true }
+wgpu-profiler = { workspace = true }

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -28,5 +28,5 @@ rend3 = { version = "^0.3.0", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wgpu = "0.19.0"
-wgpu-profiler = "0.16.0"
+wgpu = "0.20"
+wgpu-profiler = "0.17"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -16,9 +16,9 @@ arrayvec = "0.7"
 bitflags = "2"
 bytemuck = "1"
 codespan-reporting = "0.11"
-encase = { version = "0.9", features = ["glam"] }
+encase = { version = "0.10", features = ["glam"] }
 flume = "0.11"
-glam = { version = "0.28", features = ["bytemuck"] }
+glam = { workspace = true, features = ["bytemuck"] }
 log = "0.4"
 naga = { version = "22.1", features = ["wgsl-in"] }
 ordered-float = "4"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -20,7 +20,7 @@ encase = { version = "0.9", features = ["glam"] }
 flume = "0.11"
 glam = { version = "0.28", features = ["bytemuck"] }
 log = "0.4"
-naga = { version = "0.20.0", features = ["wgsl-in"] }
+naga = { version = "22.1", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."
@@ -24,9 +24,9 @@ naga = { version = "22.1", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.22.1", path = "../rend3" }
+rend3 = { version = "^0.23.0", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wgpu = "22.1"
+wgpu = "23.0"
 wgpu-profiler = "0.18"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -28,5 +28,5 @@ rend3 = { version = "^0.22.1", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wgpu = "0.20"
-wgpu-profiler = "0.17"
+wgpu = "22.1"
+wgpu-profiler = "0.18"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."
@@ -16,15 +16,15 @@ arrayvec = "0.7"
 bitflags = "2"
 bytemuck = "1"
 codespan-reporting = "0.11"
-encase = { version = "0.7", features = ["glam"] }
+encase = { version = "0.9", features = ["glam"] }
 flume = "0.11"
-glam = { version = "0.25.0", features = ["bytemuck"] }
+glam = { version = "0.28", features = ["bytemuck"] }
 log = "0.4"
 naga = { version = "0.20.0", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.20.0", path = "../rend3" }
+rend3 = { version = "^0.22.0", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rend3-routine/Cargo.toml
+++ b/rend3-routine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-routine"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Customizable Render Routines for the rend3 rendering library."
@@ -24,7 +24,7 @@ naga = { version = "0.19.0", features = ["wgsl-in"] }
 ordered-float = "4"
 parking_lot = "0.12"
 profiling = {version = "1", default-features = false }
-rend3 = { version = "^0.3.0", path = "../rend3" }
+rend3 = { version = "^0.20.0", path = "../rend3" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -358,7 +358,7 @@ fn build_forward_pipeline_inner<M: Material>(
         layout: Some(pll),
         vertex: VertexState {
             module: args.shaders.vs_module,
-            entry_point: args.shaders.vs_entry,
+            entry_point: Some(args.shaders.vs_entry),
             buffers: &[],
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         },
@@ -388,7 +388,7 @@ fn build_forward_pipeline_inner<M: Material>(
         multisample: MultisampleState { count: samples as u32, ..Default::default() },
         fragment: Some(FragmentState {
             module: args.shaders.fs_module,
-            entry_point: args.shaders.fs_entry,
+            entry_point: Some(args.shaders.fs_entry),
             targets: &[],
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -222,7 +222,7 @@ impl<M: Material> ForwardRoutine<M> {
                 if material.inner.key() != self.material_key {
                     continue;
                 }
-                {   profiling::scope!("Binding");
+                {   //////profiling::scope!("Binding"); //  Can't leave this enabled; major slowdown.
                     // If we're in cpu driven mode, we need to update the texture bind group.
                     if ctx.renderer.profile.is_cpu_driven() {
                         let texture_bind_group = material.bind_group_index.into_cpu();
@@ -230,7 +230,7 @@ impl<M: Material> ForwardRoutine<M> {
                     }
                     rpass.set_bind_group(1, per_material_bg, &[]);
                 }
-                {   profiling::scope!("Drawing");
+                {   //////profiling::scope!("Drawing"); //  Can't leave this enabled; major slowdown.
                     rpass.draw_indexed(
                         object.inner.first_index..object.inner.first_index + object.inner.index_count,
                         0,

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -213,7 +213,7 @@ impl<M: Material> ForwardRoutine<M> {
                 }
             }
             if let ProfileData::Gpu(ref bg) = ctx.eval_output.d2_texture.bg {
-                rpass.set_bind_group(2, bg, &[]);
+                rpass.set_bind_group(2, Some(&**bg), &[]);
             }
 
             profiling::scope!("Binding/drawing");
@@ -228,7 +228,7 @@ impl<M: Material> ForwardRoutine<M> {
                         let texture_bind_group = material.bind_group_index.into_cpu();
                         rpass.set_bind_group(2, ctx.data_core.material_manager.texture_bind_group(texture_bind_group), &[]);
                     }
-                    rpass.set_bind_group(1, per_material_bg, &[]);
+                    rpass.set_bind_group(1, Some(&*per_material_bg), &[]);
                 }
                 {   //////profiling::scope!("Drawing"); //  Can't leave this enabled; major slowdown.
                     rpass.draw_indexed(

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -228,7 +228,7 @@ impl<M: Material> ForwardRoutine<M> {
                         let texture_bind_group = material.bind_group_index.into_cpu();
                         rpass.set_bind_group(2, ctx.data_core.material_manager.texture_bind_group(texture_bind_group), &[]);
                     }
-                    rpass.set_bind_group(1, per_material_bg, &[]);
+                    rpass.set_bind_group(1, Some(per_material_bg), &[]);
                 }
                 {   //////profiling::scope!("Drawing"); //  Can't leave this enabled; major slowdown.
                     rpass.draw_indexed(

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -19,7 +19,7 @@ use wgpu::{
     BindGroup, BindGroupLayout, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState, DepthStencilState,
     FragmentState, IndexFormat, MultisampleState, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
     PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModule, StencilState, TextureFormat,
-    VertexState,
+    VertexState, PipelineCompilationOptions,
 };
 
 use crate::common::{CameraSpecifier, PerMaterialArchetypeInterface, WholeFrameInterfaces};
@@ -348,7 +348,9 @@ fn build_forward_pipeline_inner<M: Material>(
     let mut desc = RenderPipelineDescriptor {
         label: Some(args.name),
         layout: Some(pll),
-        vertex: VertexState { module: args.shaders.vs_module, entry_point: args.shaders.vs_entry, buffers: &[] },
+        vertex: VertexState { module: args.shaders.vs_module, entry_point: args.shaders.vs_entry, buffers: &[],
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+        },
         primitive: PrimitiveState {
             topology: PrimitiveTopology::TriangleList,
             strip_index_format: None,
@@ -377,6 +379,7 @@ fn build_forward_pipeline_inner<M: Material>(
             module: args.shaders.fs_module,
             entry_point: args.shaders.fs_entry,
             targets: &[],
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
     };

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -17,9 +17,9 @@ use rend3::{
 use serde::Serialize;
 use wgpu::{
     BindGroup, BindGroupLayout, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState, DepthStencilState,
-    FragmentState, IndexFormat, MultisampleState, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
-    PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModule, StencilState, TextureFormat,
-    VertexState, PipelineCompilationOptions,
+    FragmentState, IndexFormat, MultisampleState, PipelineCompilationOptions, PipelineLayoutDescriptor, PolygonMode,
+    PrimitiveState, PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModule, StencilState,
+    TextureFormat, VertexState,
 };
 
 use crate::common::{CameraSpecifier, PerMaterialArchetypeInterface, WholeFrameInterfaces};
@@ -348,8 +348,11 @@ fn build_forward_pipeline_inner<M: Material>(
     let mut desc = RenderPipelineDescriptor {
         label: Some(args.name),
         layout: Some(pll),
-        vertex: VertexState { module: args.shaders.vs_module, entry_point: args.shaders.vs_entry, buffers: &[],
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+        vertex: VertexState {
+            module: args.shaders.vs_module,
+            entry_point: args.shaders.vs_entry,
+            buffers: &[],
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         },
         primitive: PrimitiveState {
             topology: PrimitiveTopology::TriangleList,
@@ -379,7 +382,7 @@ fn build_forward_pipeline_inner<M: Material>(
             module: args.shaders.fs_module,
             entry_point: args.shaders.fs_entry,
             targets: &[],
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
     };

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -387,6 +387,7 @@ fn build_forward_pipeline_inner<M: Material>(
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
+        cache: None,    // (JN) no cache used
     };
     if let Some(desc_callback) = args.descriptor_callback {
         desc_callback(&mut desc, &mut render_targets);

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -228,7 +228,7 @@ impl<M: Material> ForwardRoutine<M> {
                         let texture_bind_group = material.bind_group_index.into_cpu();
                         rpass.set_bind_group(2, ctx.data_core.material_manager.texture_bind_group(texture_bind_group), &[]);
                     }
-                    rpass.set_bind_group(1, Some(per_material_bg), &[]);
+                    rpass.set_bind_group(1, per_material_bg, &[]);
                 }
                 {   //////profiling::scope!("Drawing"); //  Can't leave this enabled; major slowdown.
                     rpass.draw_indexed(

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -26,7 +26,7 @@ use crate::common::{CameraSpecifier, PerMaterialArchetypeInterface, WholeFrameIn
 use crate::uniforms::PerCameraUniform;
 
 /// This structure is unused.
-#[allow(dead_code)]  // This structure is never constructed
+#[allow(dead_code)] // This structure is never constructed
 #[derive(Serialize)]
 struct ForwardPreprocessingArguments {
     profile: Option<RendererProfile>,

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -202,6 +202,7 @@ impl<M: Material> ForwardRoutine<M> {
                 SampleCount::One => &self.pipeline_s1,
                 SampleCount::Four => &self.pipeline_s4,
             };
+            let mut rpass = rpass.borrow_mut(); // actual rpass from Rc
             rpass.set_index_buffer(ctx.eval_output.mesh_buffer.slice(..), IndexFormat::Uint32);
             rpass.set_pipeline(pipeline);
             rpass.set_bind_group(0, whole_frame_uniform_bg, &[]);

--- a/rend3-routine/src/forward.rs
+++ b/rend3-routine/src/forward.rs
@@ -25,6 +25,8 @@ use wgpu::{
 use crate::common::{CameraSpecifier, PerMaterialArchetypeInterface, WholeFrameInterfaces};
 use crate::uniforms::PerCameraUniform;
 
+/// This structure is unused.
+#[allow(dead_code)]  // This structure is never constructed
 #[derive(Serialize)]
 struct ForwardPreprocessingArguments {
     profile: Option<RendererProfile>,

--- a/rend3-routine/src/pbr/material.rs
+++ b/rend3-routine/src/pbr/material.rs
@@ -515,7 +515,7 @@ impl Material for PbrMaterial {
             self.anisotropy.to_texture(),
             self.aomr_textures.to_ao_texture(),
         ]
-        .map(|opt| opt.map(|r| r.get_raw()))
+        .map(|opt| opt.map(|r| *r.get_raw()))
     }
 
     fn to_data(&self) -> Self::DataType {

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -223,7 +223,7 @@ pub fn add_skinning_to_graph<'node>(graph: &mut RenderGraph<'node>, gpu_skinner:
         // Avoid running the compute pass if there are no skeletons. This
         // prevents binding an empty buffer
         if ctx.data_core.skeleton_manager.skeletons().len() > 0 {
-            gpu_skinner.execute_pass(&ctx, encoder, &skinning_input);
+            gpu_skinner.execute_pass(&ctx, &mut encoder.borrow_mut(), &skinning_input);
         }
     });
 }

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -17,6 +17,7 @@ use rend3::{
 use wgpu::{
     BindGroupLayout, Buffer, BufferBindingType, BufferDescriptor, BufferUsages, CommandEncoder, ComputePassDescriptor,
     ComputePipeline, ComputePipelineDescriptor, PipelineLayoutDescriptor, ShaderModuleDescriptor, ShaderStages,
+    PipelineCompilationOptions,
 };
 
 /// The per-skeleton data, as uploaded to the GPU compute shader.
@@ -173,6 +174,7 @@ impl GpuSkinner {
             layout: Some(&layout),
             module: &module,
             entry_point: "main",
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
         });
 
         Self { bgl, pipeline }

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -173,7 +173,7 @@ impl GpuSkinner {
             label: Some("Gpu skinning pipeline"),
             layout: Some(&layout),
             module: &module,
-            entry_point: "main",
+            entry_point: Some("main"),
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             cache: None,    // (JN) no cache used
         });

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -16,8 +16,8 @@ use rend3::{
 };
 use wgpu::{
     BindGroupLayout, Buffer, BufferBindingType, BufferDescriptor, BufferUsages, CommandEncoder, ComputePassDescriptor,
-    ComputePipeline, ComputePipelineDescriptor, PipelineLayoutDescriptor, ShaderModuleDescriptor, ShaderStages,
-    PipelineCompilationOptions,
+    ComputePipeline, ComputePipelineDescriptor, PipelineCompilationOptions, PipelineLayoutDescriptor,
+    ShaderModuleDescriptor, ShaderStages,
 };
 
 /// The per-skeleton data, as uploaded to the GPU compute shader.
@@ -174,7 +174,7 @@ impl GpuSkinner {
             layout: Some(&layout),
             module: &module,
             entry_point: "main",
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         });
 
         Self { bgl, pipeline }

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -217,12 +217,10 @@ pub fn add_skinning_to_graph<'node>(graph: &mut RenderGraph<'node>, gpu_skinner:
 
     builder.build(move |mut ctx| {
         let encoder = ctx.encoder_or_pass.take_encoder();
-
-        let skinning_input = build_gpu_skinning_input_buffers(&ctx);
-
         // Avoid running the compute pass if there are no skeletons. This
         // prevents binding an empty buffer
         if ctx.data_core.skeleton_manager.skeletons().len() > 0 {
+            let skinning_input = build_gpu_skinning_input_buffers(&ctx); // only do this if we have skeletons. WGPU does not like zero length buffers.
             gpu_skinner.execute_pass(&ctx, &mut encoder.borrow_mut(), &skinning_input);
         }
     });

--- a/rend3-routine/src/skinning.rs
+++ b/rend3-routine/src/skinning.rs
@@ -175,6 +175,7 @@ impl GpuSkinner {
             module: &module,
             entry_point: "main",
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
+            cache: None,    // (JN) no cache used
         });
 
         Self { bgl, pipeline }

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -101,7 +101,7 @@ impl SkyboxRoutine {
                     SampleCount::One => &self.pipelines.pipeline_s1,
                     SampleCount::Four => &self.pipelines.pipeline_s4,
                 };
-
+                let mut rpass = rpass.borrow_mut();
                 rpass.set_pipeline(pipeline);
                 rpass.set_bind_group(0, forward_uniform_bg, &[]);
                 rpass.set_bind_group(1, bg, &[]);

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -143,7 +143,7 @@ impl SkyboxPipelines {
                 layout: Some(&pll),
                 vertex: VertexState {
                     module: &skybox_sm,
-                    entry_point: "vs_main",
+                    entry_point: Some("vs_main"),
                     buffers: &[],
                     compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
                 },
@@ -166,7 +166,7 @@ impl SkyboxPipelines {
                 multisample: MultisampleState { count: samples as u32, ..Default::default() },
                 fragment: Some(FragmentState {
                     module: &skybox_sm,
-                    entry_point: "fs_main",
+                    entry_point: Some("fs_main"),
                     targets: &[Some(ColorTargetState {
                         format: TextureFormat::Rgba16Float,
                         blend: None,

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -13,6 +13,7 @@ use wgpu::{
     DepthStencilState, Face, FragmentState, FrontFace, MultisampleState, PipelineLayoutDescriptor, PolygonMode,
     PrimitiveState, PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource,
     ShaderStages, StencilState, TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
+    PipelineCompilationOptions,
 };
 
 use crate::common::WholeFrameInterfaces;
@@ -140,7 +141,9 @@ impl SkyboxPipelines {
             renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
                 label: Some("skybox pass"),
                 layout: Some(&pll),
-                vertex: VertexState { module: &skybox_sm, entry_point: "vs_main", buffers: &[] },
+                vertex: VertexState { module: &skybox_sm, entry_point: "vs_main", buffers: &[],
+                    compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+                },
                 primitive: PrimitiveState {
                     topology: PrimitiveTopology::TriangleList,
                     strip_index_format: None,
@@ -166,6 +169,7 @@ impl SkyboxPipelines {
                         blend: None,
                         write_mask: ColorWrites::all(),
                     })],
+                    compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
                 }),
                 multiview: None,
             })

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -10,10 +10,10 @@ use rend3::{
 };
 use wgpu::{
     BindGroup, BindGroupLayout, BindingType, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState,
-    DepthStencilState, Face, FragmentState, FrontFace, MultisampleState, PipelineLayoutDescriptor, PolygonMode,
-    PrimitiveState, PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource,
-    ShaderStages, StencilState, TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
-    PipelineCompilationOptions,
+    DepthStencilState, Face, FragmentState, FrontFace, MultisampleState, PipelineCompilationOptions,
+    PipelineLayoutDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor,
+    ShaderModuleDescriptor, ShaderSource, ShaderStages, StencilState, TextureFormat, TextureSampleType,
+    TextureViewDimension, VertexState,
 };
 
 use crate::common::WholeFrameInterfaces;
@@ -141,8 +141,11 @@ impl SkyboxPipelines {
             renderer.device.create_render_pipeline(&RenderPipelineDescriptor {
                 label: Some("skybox pass"),
                 layout: Some(&pll),
-                vertex: VertexState { module: &skybox_sm, entry_point: "vs_main", buffers: &[],
-                    compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+                vertex: VertexState {
+                    module: &skybox_sm,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
                 },
                 primitive: PrimitiveState {
                     topology: PrimitiveTopology::TriangleList,
@@ -169,7 +172,7 @@ impl SkyboxPipelines {
                         blend: None,
                         write_mask: ColorWrites::all(),
                     })],
-                    compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+                    compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
                 }),
                 multiview: None,
             })

--- a/rend3-routine/src/skybox.rs
+++ b/rend3-routine/src/skybox.rs
@@ -175,6 +175,7 @@ impl SkyboxPipelines {
                     compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
                 }),
                 multiview: None,
+                cache: None,    // (JN) no cache used
             })
         };
 

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -76,6 +76,7 @@ fn create_pipeline(
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
+        cache: None,    // (JN) no cache used
     })
 }
 

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -145,7 +145,7 @@ impl TonemappingRoutine {
                 Some("blit src bg"),
                 &self.bgl,
             ));
-
+            let mut rpass = rpass.borrow_mut();
             rpass.set_pipeline(&self.pipeline);
             rpass.set_bind_group(0, forward_uniform_bg, &[]);
             rpass.set_bind_group(1, blit_src_bg, &[]);

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -54,7 +54,7 @@ fn create_pipeline(
         layout: Some(&pll),
         vertex: VertexState {
             module: &module,
-            entry_point: "vs_main",
+            entry_point: Some("vs_main"),
             buffers: &[],
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         },
@@ -71,7 +71,7 @@ fn create_pipeline(
         multisample: MultisampleState::default(),
         fragment: Some(FragmentState {
             module: &module,
-            entry_point: fs_entry_point,
+            entry_point: Some(fs_entry_point),
             targets: &[Some(ColorTargetState { format: output_format, blend: None, write_mask: ColorWrites::all() })],
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -147,8 +147,8 @@ impl TonemappingRoutine {
             ));
             let mut rpass = rpass.borrow_mut();
             rpass.set_pipeline(&self.pipeline);
-            rpass.set_bind_group(0, forward_uniform_bg, &[]);
-            rpass.set_bind_group(1, blit_src_bg, &[]);
+            rpass.set_bind_group(0, Some(&*forward_uniform_bg), &[]);
+            rpass.set_bind_group(1, Some(&*blit_src_bg), &[]);
             rpass.draw(0..3, 0..1);
         });
     }

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -19,9 +19,9 @@ use rend3::{
 };
 use wgpu::{
     BindGroup, BindGroupLayout, BindingType, ColorTargetState, ColorWrites, Device, FragmentState, FrontFace,
-    MultisampleState, PipelineLayoutDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipeline,
-    RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource, ShaderStages, TextureFormat, TextureSampleType,
-    TextureViewDimension, VertexState, PipelineCompilationOptions,
+    MultisampleState, PipelineCompilationOptions, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
+    PrimitiveTopology, RenderPipeline, RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource, ShaderStages,
+    TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
 };
 
 use crate::common::WholeFrameInterfaces;
@@ -52,8 +52,11 @@ fn create_pipeline(
     device.create_render_pipeline(&RenderPipelineDescriptor {
         label: Some("tonemapping pass"),
         layout: Some(&pll),
-        vertex: VertexState { module: &module, entry_point: "vs_main", buffers: &[],
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+        vertex: VertexState {
+            module: &module,
+            entry_point: "vs_main",
+            buffers: &[],
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         },
         primitive: PrimitiveState {
             topology: PrimitiveTopology::TriangleList,
@@ -70,7 +73,7 @@ fn create_pipeline(
             module: &module,
             entry_point: fs_entry_point,
             targets: &[Some(ColorTargetState { format: output_format, blend: None, write_mask: ColorWrites::all() })],
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
     })

--- a/rend3-routine/src/tonemapping.rs
+++ b/rend3-routine/src/tonemapping.rs
@@ -21,7 +21,7 @@ use wgpu::{
     BindGroup, BindGroupLayout, BindingType, ColorTargetState, ColorWrites, Device, FragmentState, FrontFace,
     MultisampleState, PipelineLayoutDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipeline,
     RenderPipelineDescriptor, ShaderModuleDescriptor, ShaderSource, ShaderStages, TextureFormat, TextureSampleType,
-    TextureViewDimension, VertexState,
+    TextureViewDimension, VertexState, PipelineCompilationOptions,
 };
 
 use crate::common::WholeFrameInterfaces;
@@ -52,7 +52,9 @@ fn create_pipeline(
     device.create_render_pipeline(&RenderPipelineDescriptor {
         label: Some("tonemapping pass"),
         layout: Some(&pll),
-        vertex: VertexState { module: &module, entry_point: "vs_main", buffers: &[] },
+        vertex: VertexState { module: &module, entry_point: "vs_main", buffers: &[],
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+        },
         primitive: PrimitiveState {
             topology: PrimitiveTopology::TriangleList,
             strip_index_format: None,
@@ -68,6 +70,7 @@ fn create_pipeline(
             module: &module,
             entry_point: fs_entry_point,
             targets: &[Some(ColorTargetState { format: output_format, blend: None, write_mask: ColorWrites::all() })],
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
         }),
         multiview: None,
     })

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."
@@ -20,8 +20,8 @@ flume = { version = "0.11", features = ["spin"] }
 glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
-rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
-wgpu = "22.1"
+rend3-routine = { version = "0.23.0", path = "../rend3-routine" }
+wgpu = "23.0"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests
 # and not need to have conditional attributes on every single test.

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."
@@ -20,7 +20,7 @@ flume = { version = "0.11", features = ["spin"] }
 glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
-rend3-routine = { version = "0.23.1", path = "../rend3-routine" }
+rend3-routine = { path = "../rend3-routine" }
 wgpu = "23.0"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -17,7 +17,7 @@ name = "rend3-tests"
 anyhow = "1"
 env_logger = "0.11"
 flume = { version = "0.11", features = ["spin"] }
-glam = "0.28"
+glam = { workspace = true }
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
 rend3-routine = { path = "../rend3-routine" }

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1"
 env_logger = "0.11"
 flume = { version = "0.11", features = ["spin"] }
 glam = "0.25"
-image = { version =  "0.24", default-features = false, features = ["png"] }
+image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
 rend3-routine = { path = "../rend3-routine" }
 wgpu = "0.20"

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."
@@ -20,8 +20,8 @@ flume = { version = "0.11", features = ["spin"] }
 glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
-rend3-routine = { path = "../rend3-routine" }
-wgpu = "22.0"
+rend3-routine = { version = "0.22.1", path = "../rend3-routine" }
+wgpu = "22.1"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests
 # and not need to have conditional attributes on every single test.

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."
@@ -17,11 +17,11 @@ name = "rend3-tests"
 anyhow = "1"
 env_logger = "0.11"
 flume = { version = "0.11", features = ["spin"] }
-glam = "0.25"
+glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
 rend3-routine = { path = "../rend3-routine" }
-wgpu = "0.20"
+wgpu = "22.0"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests
 # and not need to have conditional attributes on every single test.

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -21,7 +21,7 @@ glam = "0.25"
 image = { version =  "0.24", default-features = false, features = ["png"] }
 rend3 = { path = "../rend3" }
 rend3-routine = { path = "../rend3-routine" }
-wgpu = "0.19.0"
+wgpu = "0.20"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests
 # and not need to have conditional attributes on every single test.

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -21,7 +21,7 @@ glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
 rend3-routine = { path = "../rend3-routine" }
-wgpu = "23.0"
+wgpu = { workspace = true }
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests
 # and not need to have conditional attributes on every single test.

--- a/rend3-test/Cargo.toml
+++ b/rend3-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-test"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Testing utilities for rend3."
@@ -20,7 +20,7 @@ flume = { version = "0.11", features = ["spin"] }
 glam = "0.28"
 image = { version =  "0.25", default-features = false, features = ["png", "jpeg"] }
 rend3 = { path = "../rend3" }
-rend3-routine = { version = "0.23.0", path = "../rend3-routine" }
+rend3-routine = { version = "0.23.1", path = "../rend3-routine" }
 wgpu = "23.0"
 
 # These should be dev-deps but doing this allows us to have a single attribute on all tests

--- a/rend3-test/src/runner.rs
+++ b/rend3-test/src/runner.rs
@@ -11,7 +11,7 @@ use rend3::{
 };
 use rend3_routine::{base::BaseRenderGraph, pbr::PbrRoutine, tonemapping::TonemappingRoutine};
 use wgpu::{
-    Extent3d, ImageCopyBuffer, ImageDataLayout, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
+    Extent3d, TexelCopyBufferInfo, TexelCopyBufferLayout, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 
 use crate::{helpers::CaptureDropGuard, ThresholdSet};
@@ -198,9 +198,9 @@ pub async fn download_image(
         renderer.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("Test output encoder") });
     encoder.copy_texture_to_buffer(
         texture.as_image_copy(),
-        ImageCopyBuffer {
+        TexelCopyBufferInfo {
             buffer: &buffer,
-            layout: ImageDataLayout { offset: 0, bytes_per_row: Some(size.x * 4), rows_per_image: None },
+            layout: TexelCopyBufferLayout { offset: 0, bytes_per_row: Some(size.x * 4), rows_per_image: None },
         },
         Extent3d { width: size.x, height: size.y, depth_or_array_layers: 1 },
     );

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -20,4 +20,4 @@ glam = { version = "0.25", features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
-wgt = { package = "wgpu-types", version = "0.19" }
+wgt = { package = "wgpu-types", version = "0.20" }

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."
@@ -20,4 +20,4 @@ glam = { version = "0.28", features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
-wgt = { package = "wgpu-types", version = "22.0" }
+wgt = { package = "wgpu-types", version = "23.0" }

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."
@@ -15,9 +15,9 @@ rust-version = "1.71"
 bitflags = "2"
 bytemuck = { version = "1", features = ["min_const_generics"] }
 cfg-if = "1"
-encase = { version = "0.7", features = ["glam"] }
-glam = { version = "0.25", features = ["bytemuck"] }
+encase = { version = "0.9", features = ["glam"] }
+glam = { version = "0.28", features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
-wgt = { package = "wgpu-types", version = "0.20" }
+wgt = { package = "wgpu-types", version = "22.0" }

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -20,4 +20,5 @@ glam = { version = "0.28", features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
-wgt = { package = "wgpu-types", version = "23.0" }
+wgpu-types = { workspace = true }
+wgt = { package = "wgpu-types", version = "*" }

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.23.1"
+version.workspace = true 
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.71"
 bitflags = "2"
 bytemuck = { version = "1", features = ["min_const_generics"] }
 cfg-if = "1"
-encase = { version = "0.9", features = ["glam"] }
-glam = { version = "0.28", features = ["bytemuck"] }
+encase = { version = "0.10", features = ["glam"] }
+glam = { workspace = true, features = ["bytemuck"] }
 list-any = "0.2"
 once_cell = "1"
 thiserror = "1"

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3-types"
-version = "0.3.0"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Type definitions for the rend3 rendering library."

--- a/rend3-types/Cargo.toml
+++ b/rend3-types/Cargo.toml
@@ -21,4 +21,4 @@ list-any = "0.2"
 once_cell = "1"
 thiserror = "1"
 wgpu-types = { workspace = true }
-wgt = { package = "wgpu-types", version = "*" }
+####wgt = { package = "wgpu-types", version = "24.0.0" }

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -991,7 +991,7 @@ pub struct Texture {
 }
 
 /// Describes a texture made from the mipmaps of another texture.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TextureFromTexture {
     pub label: Option<String>,
     pub src: RawTexture2DHandle,

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -85,7 +85,7 @@ type ResourceDeindexer: dyn Fn(RawResourceHandle<T>);
 /// Soundness:
 /// - Deindexer can be called only once - yes
 //  - Deindexer will always be called on drop - yes.
-struct ResourceHandleRefcount<T: 'static> {
+struct ResourceHandleRefcount<T> {
     /// Called at drop to delete the item from the index.
     #[cfg(not(target_arch = "wasm32"))]
     deindexer: &'static(dyn Fn(RawResourceHandle<T>) + Send + Sync),

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -100,7 +100,7 @@ impl<T> ResourceHandleRefcount<T> {
     /// Usual new fn
     pub fn new(destroy_fn: impl Fn(RawResourceHandle<T>) + WasmNotSend + WasmNotSync + 'static, idx: usize) -> Self {
         Self {
-            deindexer: Arc::new(destroy_fn),
+            deindexer: &destroy_fn,
             raw: RawResourceHandle { idx, _phantom: PhantomData },
         }
     }
@@ -160,7 +160,7 @@ impl<T> Drop for ResourceHandle<T> {
 impl<T> Debug for ResourceHandle<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResourceHandle")
-            .field("refcount", &Arc::strong_count(&self.refcount.deindexer))
+            .field("refcount", &Arc::strong_count(&self.refcount))
             .field("idx", &self.get_raw().idx)
             .finish()
     }
@@ -202,7 +202,7 @@ impl<T> ResourceHandle<T> {
     ///
     /// Part of rend3's internal interface for accessing internal resrouces
     pub fn get_raw(&self) -> RawResourceHandle<T> {
-        self.refcount.get_raw()
+        self.refcount.raw
     }
 }
 
@@ -210,7 +210,7 @@ impl<T> Deref for ResourceHandle<T> {
     type Target = RawResourceHandle<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.get_raw()
+        &self.refcount.raw
     }
 }
 

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -317,6 +317,7 @@ macro_rules! changeable_struct {
 
 // WGPU REEXPORTS
 #[doc(inline)]
+pub use wgpu_types as wgt;
 pub use wgt::{
     AstcBlock, AstcChannel, Backend, Backends, Color, DeviceType, PresentMode, TextureFormat,
     TextureFormatFeatureFlags, TextureUsages,

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -88,9 +88,9 @@ type ResourceDeindexer: dyn Fn(RawResourceHandle<T>);
 struct ResourceHandleRefcount<T> {
     /// Called at drop to delete the item from the index.
     #[cfg(not(target_arch = "wasm32"))]
-    deindexer: &'static(dyn Fn(RawResourceHandle<T>) + Send + Sync),
+    deindexer: dyn Fn(RawResourceHandle<T>) + WasmNotSend + WasmNotSync + 'static,
     #[cfg(target_arch = "wasm32")]
-    deindexer: &'static(dyn Fn(RawResourceHandle<T>)),
+    deindexer: dyn Fn(RawResourceHandle<T>) + WasmNotSend + WasmNotSync + 'static,
     //////deindexer: ResourceDeindexer
     /// Index to the resource
     raw: RawResourceHandle<T>,
@@ -100,7 +100,7 @@ impl<T> ResourceHandleRefcount<T> {
     /// Usual new fn
     pub fn new(destroy_fn: impl Fn(RawResourceHandle<T>) + WasmNotSend + WasmNotSync + 'static, idx: usize) -> Self {
         Self {
-            deindexer: &destroy_fn,
+            deindexer: destroy_fn,
             raw: RawResourceHandle { idx, _phantom: PhantomData },
         }
     }

--- a/rend3-types/src/lib.rs
+++ b/rend3-types/src/lib.rs
@@ -52,6 +52,7 @@ impl<T> Debug for RawResourceHandle<T> {
 /// ***IT IS UNSAFE THAT THIS IS COPYABLE***
 /// This may result in a RawResourceHandle outliving the index entry to which it points.
 /// ***NEEDS WORK***
+////// /*
 impl<T> Copy for RawResourceHandle<T> {}
 
 impl<T> Clone for RawResourceHandle<T> {
@@ -59,7 +60,7 @@ impl<T> Clone for RawResourceHandle<T> {
         *self
     }
 }
-
+////// */
 impl<T> PartialEq for RawResourceHandle<T> {
     fn eq(&self, other: &Self) -> bool {
         self.idx == other.idx

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -51,7 +51,7 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.3"
-rend3-types = { version = "0.23.0", path = "../rend3-types" }
+rend3-types = { version = "0.23.1", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -50,7 +50,7 @@ num-traits = "0.2"
 once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
-range-alloc = "0.1.3"
+range-alloc = "0.1.4"
 rend3-types = { version = "0.23.1", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -58,8 +58,8 @@ serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "23.0"
-wgpu-profiler = "0.19"
+wgpu = { workspace = true }
+wgpu-profiler = { workspace = true }
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -51,15 +51,15 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.3"
-rend3-types = { version = "0.22.1", path = "../rend3-types" }
+rend3-types = { version = "0.23.0", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "22.1"
-wgpu-profiler = "0.18"
+wgpu = "23.0"
+wgpu-profiler = "0.18.3"
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -38,9 +38,9 @@ bimap = "0.6"
 bitflags = "2"
 bumpalo = "3"
 bytemuck = "1"
-encase = { version = "0.9" }
+encase = { version = "0.10" }
 flume = "0.11"
-glam = { version = "0.28", features = ["bytemuck"] }
+glam = { workspace = true, features = ["bytemuck"] }
 handlebars = "5"
 indexmap = "2"
 list-any = "0.2"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.3.1"
+version = "0.20.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -51,7 +51,7 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.3"
-rend3-types = { version = "^0.3.0", path = "../rend3-types" }
+rend3-types = { version = "^0.20.0", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -59,7 +59,7 @@ smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
 wgpu = "23.0"
-wgpu-profiler = "0.18.3"
+wgpu-profiler = "0.19"
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -51,15 +51,15 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.3"
-rend3-types = { version = "0.22.0", path = "../rend3-types" }
+rend3-types = { version = "0.22.1", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "22.0"
-wgpu-profiler = "0.17"
+wgpu = "22.1"
+wgpu-profiler = "0.18"
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.20.0"
+version = "0.22.0"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -38,9 +38,9 @@ bimap = "0.6"
 bitflags = "2"
 bumpalo = "3"
 bytemuck = "1"
-encase = { version = "0.7" }
+encase = { version = "0.9" }
 flume = "0.11"
-glam = { version = "0.25.0", features = ["bytemuck"] }
+glam = { version = "0.28", features = ["bytemuck"] }
 handlebars = "5"
 indexmap = "2"
 list-any = "0.2"
@@ -51,14 +51,14 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.3"
-rend3-types = { version = "^0.20.0", path = "../rend3-types" }
+rend3-types = { version = "0.22.0", path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "0.20"
+wgpu = "22.0"
 wgpu-profiler = "0.17"
 
 [dev-dependencies]

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -58,8 +58,8 @@ serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 smartstring = "1.0"
 thiserror = "1"
-wgpu = "0.19.0"
-wgpu-profiler = "0.16.0"
+wgpu = "0.20"
+wgpu-profiler = "0.17"
 
 [dev-dependencies]
 pollster = "0.3"

--- a/rend3/Cargo.toml
+++ b/rend3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rend3"
-version = "0.23.1"
+version.workspace = true
 authors = ["The rend3 Developers"]
 edition = "2021"
 description = "Easy to use, customizable, efficient 3D renderer library built on wgpu."
@@ -51,7 +51,7 @@ once_cell = "1"
 parking_lot = "0.12"
 profiling = { version = "1", default-features = false }
 range-alloc = "0.1.4"
-rend3-types = { version = "0.23.1", path = "../rend3-types" }
+rend3-types = { path = "../rend3-types" }
 rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 rustc-hash = "1"
 serde = { version = "1", features = ["derive"] }

--- a/rend3/src/graph/encpass.rs
+++ b/rend3/src/graph/encpass.rs
@@ -74,7 +74,7 @@ impl RenderGraphEncoderOrPass {
     /// # Panics
     ///
     /// - If a take_* function is called twice.
-    pub fn take_rpass(&mut self, _handle: DeclaredDependency<RenderPassHandle>) -> Rc<RefCell<RenderPass>> {
+    pub fn take_rpass(&mut self, _handle: DeclaredDependency<RenderPassHandle>) -> Rc<RefCell<RenderPass<'static>>> {
         match mem::take(&mut self.0) {
             RenderGraphEncoderOrPassInner::Encoder(_) => {
                 panic!("Internal rendergraph error: trying to get renderpass when one was not asked for")

--- a/rend3/src/graph/graph.rs
+++ b/rend3/src/graph/graph.rs
@@ -612,14 +612,15 @@ impl<'node> RenderGraph<'node> {
                 stencil_ops: stencil_load,
             }
         });
-        let render_pass = encoder.begin_render_pass(&RenderPassDescriptor {
+        let mut binding = encoder.borrow_mut();
+        let render_pass = binding.begin_render_pass(&RenderPassDescriptor {
             label: None,
             color_attachments: &color_attachments,
             depth_stencil_attachment,
             timestamp_writes: None,
             occlusion_query_set: None,
         });
-        Rc::new(RefCell::new(render_pass))  // return mutable form.
+        Rc::new(RefCell::new(render_pass.forget_lifetime()))  // return internally mutable form not tied to encoder lifetime
     }
 }
 

--- a/rend3/src/graph/node.rs
+++ b/rend3/src/graph/node.rs
@@ -21,7 +21,7 @@ pub struct NodeExecutionContext<'a, 'pass, 'node: 'pass> {
     /// Reference to the renderer data behind a lock.
     pub data_core: &'pass RendererDataCore,
     /// Either the asked-for renderpass or a command encoder.
-    pub encoder_or_pass: RenderGraphEncoderOrPass<'a, 'pass>,
+    pub encoder_or_pass: RenderGraphEncoderOrPass,
     /// Storage for any temporary data that needs to live as long
     /// as the renderpass.
     pub temps: &'pass RpassTemporaryPool<'pass>,

--- a/rend3/src/instruction.rs
+++ b/rend3/src/instruction.rs
@@ -19,8 +19,15 @@ trait_supertrait_alias!(pub AddMaterialFillInvoke: FnOnce(&mut MaterialManager, 
 trait_supertrait_alias!(pub ChangeMaterialChangeInvoke: FnOnce(&mut MaterialManager, &Device, &TextureManager<crate::types::Texture2DTag>, RawMaterialHandle) + WasmNotSend + WasmNotSync);
 trait_supertrait_alias!(pub AddGraphDataAddInvoke: FnOnce(&mut GraphStorage) + WasmNotSend);
 
+/// Instructions are the basic operations performed by the renderer.
+/// The user queues them up by making requests of Rend3,
+/// and they are all executed at the beginning
+/// of each frame render.
 pub struct Instruction {
+    /// The actual instruction item.
     pub kind: InstructionKind,
+    /// This field is not used.
+    #[allow(dead_code)]
     pub location: Location<'static>,
 }
 

--- a/rend3/src/managers/directional.rs
+++ b/rend3/src/managers/directional.rs
@@ -81,18 +81,18 @@ impl DirectionalLightManager {
         }
     }
 
-    pub fn add(&mut self, handle: RawDirectionalLightHandle, light: DirectionalLight) {
+    pub fn add(&mut self, handle: &RawDirectionalLightHandle, light: DirectionalLight) {
         if handle.idx >= self.data.len() {
             self.data.resize_with(handle.idx + 1, || None);
         }
         self.data[handle.idx] = Some(InternalDirectionalLight { inner: light })
     }
 
-    pub fn update(&mut self, handle: RawDirectionalLightHandle, change: DirectionalLightChange) {
+    pub fn update(&mut self, handle: &RawDirectionalLightHandle, change: DirectionalLightChange) {
         self.data[handle.idx].as_mut().unwrap().inner.update_from_changes(change);
     }
 
-    pub fn remove(&mut self, handle: RawDirectionalLightHandle) {
+    pub fn remove(&mut self, handle: &RawDirectionalLightHandle) {
         self.data[handle.idx].take().unwrap();
     }
 

--- a/rend3/src/managers/directional/shadow_alloc.rs
+++ b/rend3/src/managers/directional/shadow_alloc.rs
@@ -15,13 +15,13 @@ impl ShadowNode {
         nodes: &mut Vec<ShadowNode>,
         node_idx: usize,
         relative_order: u32,
-        handle: RawDirectionalLightHandle,
+        handle: &RawDirectionalLightHandle,
     ) -> bool {
         let this = &mut nodes[node_idx];
         match *this {
             ShadowNode::Vacant => {
                 if relative_order == 0 {
-                    *this = ShadowNode::Leaf(handle);
+                    *this = ShadowNode::Leaf(*handle);
 
                     true
                 } else {
@@ -84,7 +84,7 @@ pub(super) fn allocate_shadow_atlas(
         let order = resolution.leading_zeros() - min_leading_zeros;
 
         loop {
-            if ShadowNode::try_alloc(&mut nodes, *roots.last().unwrap(), order, handle) {
+            if ShadowNode::try_alloc(&mut nodes, *roots.last().unwrap(), order, &handle) {
                 break;
             }
 
@@ -147,7 +147,7 @@ mod tests {
     fn chunk_subdivision_single() {
         let mut nodes = vec![ShadowNode::Vacant];
 
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 0, RDLH::new(0)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 0, &RDLH::new(0)));
         assert_eq!(&nodes, &[ShadowNode::Leaf(RDLH::new(0))]);
     }
 
@@ -155,8 +155,8 @@ mod tests {
     fn chunk_subdivision_single_failure() {
         let mut nodes = vec![ShadowNode::Vacant];
 
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 0, RDLH::new(0)));
-        assert!(!ShadowNode::try_alloc(&mut nodes, 0, 0, RDLH::new(1)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 0, &RDLH::new(0)));
+        assert!(!ShadowNode::try_alloc(&mut nodes, 0, 0, &RDLH::new(1)));
         assert_eq!(&nodes, &[ShadowNode::Leaf(RDLH::new(0))]);
     }
 
@@ -164,8 +164,8 @@ mod tests {
     fn chunk_subdivision_multiple() {
         let mut nodes = vec![ShadowNode::Vacant];
 
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(0)));
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(1)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(0)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(1)));
         assert_eq!(
             &nodes,
             &[
@@ -183,9 +183,9 @@ mod tests {
         let mut nodes = vec![ShadowNode::Vacant];
 
         for i in 0..4 {
-            assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(i)));
+            assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(i)));
         }
-        assert!(!ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(5)));
+        assert!(!ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(5)));
         assert_eq!(
             &nodes,
             &[
@@ -202,11 +202,11 @@ mod tests {
     fn chunk_subdivision_multiple_nested() {
         let mut nodes = vec![ShadowNode::Vacant];
 
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(0)));
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(1)));
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 2, RDLH::new(2)));
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, RDLH::new(3)));
-        assert!(ShadowNode::try_alloc(&mut nodes, 0, 2, RDLH::new(4)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(0)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(1)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 2, &RDLH::new(2)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 1, &RDLH::new(3)));
+        assert!(ShadowNode::try_alloc(&mut nodes, 0, 2, &RDLH::new(4)));
         assert_eq!(
             &nodes,
             &[

--- a/rend3/src/managers/handle_alloc.rs
+++ b/rend3/src/managers/handle_alloc.rs
@@ -34,7 +34,8 @@ where
         let idx = maybe_idx.unwrap_or_else(|| self.max_allocated.fetch_add(1, Ordering::Relaxed));
 
         let renderer = Arc::clone(renderer);
-        let destroy_fn = move |handle: RawResourceHandle<T>| {
+        //  Note copy of raw resource handle. May result in resource handle outliving its index.
+        let destroy_fn = move |handle: &RawResourceHandle<T>| {
             renderer.instructions.push(handle.into_delete_instruction_kind(), *Location::caller())
         };
 

--- a/rend3/src/managers/handle_alloc.rs
+++ b/rend3/src/managers/handle_alloc.rs
@@ -29,6 +29,7 @@ where
         Self { max_allocated: AtomicUsize::new(0), freelist: Mutex::new(Vec::new()), _phantom: PhantomData }
     }
 
+    /// Allocate a handle.
     pub fn allocate(&self, renderer: &Arc<Renderer>) -> ResourceHandle<T> {
         let maybe_idx = self.freelist.lock().pop();
         let idx = maybe_idx.unwrap_or_else(|| self.max_allocated.fetch_add(1, Ordering::Relaxed));
@@ -42,6 +43,7 @@ where
         ResourceHandle::new(destroy_fn, idx)
     }
 
+    /// Deallocate a raw handle. This consumes the handle.
     pub fn deallocate(&self, handle: RawResourceHandle<T>) {
         let idx = handle.idx;
         self.freelist.lock().push(idx);

--- a/rend3/src/managers/material.rs
+++ b/rend3/src/managers/material.rs
@@ -141,7 +141,7 @@ impl MaterialManager {
         device: &Device,
         profile: RendererProfile,
         texture_manager_2d: &mut TextureManager<crate::types::Texture2DTag>,
-        handle: RawMaterialHandle,
+        handle: &RawMaterialHandle,
         material: M,
     ) {
         let bind_group_index = if profile == RendererProfile::CpuDriven {
@@ -165,14 +165,14 @@ impl MaterialManager {
         data_vec[handle.idx] = Some(InternalMaterial { bind_group_index, inner: material });
         drop(data_vec);
 
-        self.handle_to_typeid.insert(handle, TypeId::of::<M>());
+        self.handle_to_typeid.insert(*handle, TypeId::of::<M>());
     }
 
     pub fn update<M: Material>(
         &mut self,
         device: &Device,
         texture_manager_2d: &TextureManager<crate::types::Texture2DTag>,
-        handle: RawMaterialHandle,
+        handle: &RawMaterialHandle,
         material: M,
     ) {
         let type_id = self.handle_to_typeid[&handle];
@@ -196,11 +196,11 @@ impl MaterialManager {
         internal.inner = material;
     }
 
-    pub fn remove(&mut self, handle: RawMaterialHandle) {
-        let type_id = self.handle_to_typeid.remove(&handle).unwrap();
+    pub fn remove(&mut self, handle: &RawMaterialHandle) {
+        let type_id = self.handle_to_typeid.remove(handle).unwrap();
 
         let archetype = self.archetypes.get_mut(&type_id).unwrap();
-        let bind_group_index = (archetype.remove_data)(&mut archetype.data_vec, handle);
+        let bind_group_index = (archetype.remove_data)(&mut archetype.data_vec, *handle);
 
         if let ProfileData::Cpu(index) = bind_group_index {
             self.texture_deduplicator.remove(index);
@@ -259,8 +259,8 @@ impl MaterialManager {
         );
     }
 
-    pub(super) fn call_object_add_callback(&self, handle: RawMaterialHandle, args: ObjectAddCallbackArgs) {
-        let type_id = self.handle_to_typeid[&handle];
+    pub(super) fn call_object_add_callback(&self, handle: &RawMaterialHandle, args: ObjectAddCallbackArgs) {
+        let type_id = self.handle_to_typeid[handle];
 
         let archetype = &self.archetypes[&type_id];
 

--- a/rend3/src/managers/material/texture_dedupe.rs
+++ b/rend3/src/managers/material/texture_dedupe.rs
@@ -87,7 +87,7 @@ impl TextureDeduplicator {
             .enumerate()
             .map(|(idx, handle)| {
                 let view = if let Some(handle) = *handle {
-                    texture_manager_2d.get_view(handle)
+                    texture_manager_2d.get_view(&handle)
                 } else {
                     texture_manager_2d.get_null_view()
                 };

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -194,7 +194,7 @@ impl MeshManager {
         drop(data_guard);
     }
 
-    pub fn remove(&self, object_id: RawMeshHandle) {
+    pub fn remove(&self, object_id: &RawMeshHandle) {
         let mesh = self.data.lock()[object_id.idx].take().unwrap();
 
         let mut buffer_state = self.buffer_state.lock();

--- a/rend3/src/managers/mesh.rs
+++ b/rend3/src/managers/mesh.rs
@@ -314,6 +314,6 @@ impl<'a> Index<RawMeshHandle> for LockedInternalMeshDataArray<'a> {
     type Output = InternalMesh;
 
     fn index(&self, handle: RawMeshHandle) -> &Self::Output {
-        self.0[handle.idx].as_ref().unwrap()
+        self.0[handle.idx].as_ref().expect("Entry in LockedInternalMeshDataArray should not be None")
     }
 }

--- a/rend3/src/managers/object.rs
+++ b/rend3/src/managers/object.rs
@@ -119,7 +119,7 @@ impl ObjectManager {
     pub fn add(
         &mut self,
         device: &Device,
-        handle: RawObjectHandle,
+        handle: &RawObjectHandle,
         object: Object,
         mesh_manager: &MeshManager,
         skeleton_manager: &SkeletonManager,
@@ -139,12 +139,13 @@ impl ObjectManager {
         };
 
         material_manager.call_object_add_callback(
-            *object.material,
-            ObjectAddCallbackArgs { device, manager: self, internal_mesh, skeleton_ranges, handle, object },
+            &object.material.clone(),
+            //  Note copy of handle. May create a raw handle lifetime problem.
+            ObjectAddCallbackArgs { device, manager: self, internal_mesh, skeleton_ranges, handle: *handle, object },
         );
     }
 
-    pub fn set_object_transform(&mut self, handle: RawObjectHandle, transform: Mat4) {
+    pub fn set_object_transform(&mut self, handle: &RawObjectHandle, transform: Mat4) {
         let type_id = self.handle_to_typeid[&handle];
 
         let archetype = self.archetype.get_mut(&type_id).unwrap();
@@ -152,7 +153,7 @@ impl ObjectManager {
         (archetype.set_object_transform)(&mut archetype.data_vec, &mut archetype.buffer, handle.idx, transform);
     }
 
-    pub fn remove(&mut self, handle: RawObjectHandle) {
+    pub fn remove(&mut self, handle: &RawObjectHandle) {
         let type_id = self.handle_to_typeid[&handle];
 
         let archetype = self.archetype.get_mut(&type_id).unwrap();
@@ -205,7 +206,7 @@ impl ObjectManager {
 
         let dst_obj = (archetype.duplicate_object)(&mut archetype.data_vec, src_handle.idx, change);
 
-        self.add(device, dst_handle, dst_obj, mesh_manager, skeleton_manager, material_manager);
+        self.add(device, &dst_handle, dst_obj, mesh_manager, skeleton_manager, material_manager);
     }
 }
 

--- a/rend3/src/managers/point.rs
+++ b/rend3/src/managers/point.rs
@@ -39,7 +39,7 @@ impl PointLightManager {
         }
     }
 
-    pub fn add(&mut self, handle: RawPointLightHandle, light: PointLight) {
+    pub fn add(&mut self, handle: &RawPointLightHandle, light: PointLight) {
         if handle.idx >= self.data.len() {
             self.data.resize(handle.idx + 1, None);
         }
@@ -51,7 +51,7 @@ impl PointLightManager {
         self.data[handle.idx].as_mut().unwrap().update_from_changes(change);
     }
 
-    pub fn remove(&mut self, handle: RawPointLightHandle) {
+    pub fn remove(&mut self, handle: &RawPointLightHandle) {
         self.data[handle.idx].take().unwrap();
     }
 

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -69,7 +69,7 @@ impl SkeletonManager {
         mesh_manager: &MeshManager,
         skeleton: Skeleton,
     ) -> Result<InternalSkeleton, SkeletonCreationError> {
-        let internal_mesh = &mesh_manager.lock_internal_data()[skeleton.mesh.get_raw()];
+        let internal_mesh = &mesh_manager.lock_internal_data()[*skeleton.mesh.get_raw()];
         let required_joint_count =
             internal_mesh.required_joint_count.ok_or(SkeletonCreationError::MissingAttributesJointIndices)?;
 

--- a/rend3/src/managers/skeleton.rs
+++ b/rend3/src/managers/skeleton.rs
@@ -136,7 +136,7 @@ impl SkeletonManager {
         self.skeleton_count += 1;
     }
 
-    pub fn remove(&mut self, mesh_manager: &MeshManager, handle: RawSkeletonHandle) {
+    pub fn remove(&mut self, mesh_manager: &MeshManager, handle: &RawSkeletonHandle) {
         let skeleton = self.data[handle.idx].take().unwrap();
         self.global_joint_count -= skeleton.joint_matrices.len();
 
@@ -148,7 +148,7 @@ impl SkeletonManager {
         self.skeleton_count -= 1;
     }
 
-    pub fn set_joint_matrices(&mut self, handle: RawSkeletonHandle, mut joint_matrices: Vec<Mat4>) {
+    pub fn set_joint_matrices(&mut self, handle: &RawSkeletonHandle, mut joint_matrices: Vec<Mat4>) {
         let skeleton = self.data[handle.idx].as_mut().unwrap();
         assert!(
             skeleton.joint_matrices.len() <= joint_matrices.len(),

--- a/rend3/src/managers/texture.rs
+++ b/rend3/src/managers/texture.rs
@@ -278,7 +278,7 @@ impl<T: 'static> TextureManager<T> {
         self.data[handle.idx].as_ref().unwrap()
     }
 
-    pub fn get_view(&self, handle: RawResourceHandle<T>) -> &TextureView {
+    pub fn get_view(&self, handle: &RawResourceHandle<T>) -> &TextureView {
         &self.data[handle.idx].as_ref().unwrap().view
     }
 

--- a/rend3/src/managers/texture.rs
+++ b/rend3/src/managers/texture.rs
@@ -250,7 +250,7 @@ impl<T: 'static> TextureManager<T> {
         self.data[handle.idx] = Some(internal_texture);
     }
 
-    pub fn remove(&mut self, handle: RawResourceHandle<T>) {
+    pub fn remove(&mut self, handle: &RawResourceHandle<T>) {
         self.group_dirty = self.group_dirty.map_gpu(|_| true);
 
         self.data[handle.idx] = None;

--- a/rend3/src/managers/texture.rs
+++ b/rend3/src/managers/texture.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use wgpu::{
     util::DeviceExt, BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingResource, BindingType, CommandBuffer, CommandEncoder, CommandEncoderDescriptor,
-    Device, Extent3d, Features, ImageCopyTexture, ImageDataLayout, Origin3d, ShaderStages, Texture, TextureAspect,
+    Device, Extent3d, Features, TexelCopyTextureInfo, TexelCopyBufferLayout, Origin3d, ShaderStages, Texture, TextureAspect,
     TextureDescriptor, TextureDimension, TextureSampleType, TextureView, TextureViewDescriptor, TextureViewDimension,
 };
 
@@ -157,14 +157,14 @@ impl<T: 'static> TextureManager<T> {
                 let scope = AllocationErrorScope::new(&renderer.device);
                 // write first level
                 renderer.queue.write_texture(
-                    ImageCopyTexture {
+                    TexelCopyTextureInfo {
                         texture: &tex,
                         mip_level: 0,
                         origin: Origin3d::ZERO,
                         aspect: TextureAspect::All,
                     },
                     &texture.data,
-                    ImageDataLayout {
+                    TexelCopyBufferLayout {
                         offset: 0,
                         bytes_per_row: Some(block_size * (size.width / block_width)),
                         rows_per_image: None,
@@ -222,13 +222,13 @@ impl<T: 'static> TextureManager<T> {
             profiling::scope!("mip level generation");
 
             encoder.copy_texture_to_texture(
-                ImageCopyTexture {
+                TexelCopyTextureInfo {
                     texture: old_texture,
                     mip_level: old_mip,
                     origin: Origin3d::ZERO,
                     aspect: TextureAspect::All,
                 },
-                ImageCopyTexture {
+                TexelCopyTextureInfo {
                     texture: &tex,
                     mip_level: new_mip,
                     origin: Origin3d::ZERO,

--- a/rend3/src/renderer/error.rs
+++ b/rend3/src/renderer/error.rs
@@ -34,6 +34,10 @@ pub enum LimitType {
     MaxComputeWorkgroupSizeZ,
     MaxComputeWorkgroupsPerDimension,
     MaxBufferSize,
+    MaxColorAttachmentBytesPerSample,
+    MaxColorAttachments,
+    MaxSubgroupSize,
+    MinSubgroupSize,
 }
 
 /// Reason why the renderer failed to initialize.

--- a/rend3/src/renderer/eval.rs
+++ b/rend3/src/renderer/eval.rs
@@ -38,6 +38,10 @@ fn check_instructions(renderer: &Renderer, instructions: &Vec<Instruction>) {
     profiling::scope!("Instruction checking");
     let mut deleted_object_handles = HashSet::new();
     let mut deleted_mesh_handles = HashSet::new();
+    //  Preallocate. 
+    deleted_object_handles.reserve(instructions.len());
+    deleted_mesh_handles.reserve(instructions.len());
+    //  Prescan instructions for problems.
     for Instruction { kind, location : _} in instructions. iter() {
         match kind {
             InstructionKind::AddObject { handle, object } => {

--- a/rend3/src/renderer/eval.rs
+++ b/rend3/src/renderer/eval.rs
@@ -10,7 +10,7 @@ use std::collections::{HashSet};
 
 /// Set to true to check instructions for deletion before use.
 /// This is a debug trap.
-const CHECK_INSTRUCTIONS: bool = true;
+const CHECK_INSTRUCTIONS: bool = false; // didn't fail in 20 hour test.
 
 /// Instruction checker. Checks for instructions which delete an object preceding instructions which use that object.
 /// This is a debug trap for a race condition.

--- a/rend3/src/renderer/eval.rs
+++ b/rend3/src/renderer/eval.rs
@@ -107,7 +107,7 @@ pub fn evaluate_instructions(renderer: &Renderer) -> InstructionEvaluationOutput
                 InstructionKind::AddObject { handle, object } => {
                     data_core.object_manager.add(
                         &renderer.device,
-                        handle,
+                        &handle,
                         object,
                         &renderer.mesh_manager,
                         &data_core.skeleton_manager,
@@ -115,19 +115,19 @@ pub fn evaluate_instructions(renderer: &Renderer) -> InstructionEvaluationOutput
                     );
                 }
                 InstructionKind::SetObjectTransform { handle, transform } => {
-                    data_core.object_manager.set_object_transform(handle, transform);
+                    data_core.object_manager.set_object_transform(&handle, transform);
                 }
                 InstructionKind::SetSkeletonJointDeltas { handle, joint_matrices } => {
-                    data_core.skeleton_manager.set_joint_matrices(handle, joint_matrices);
+                    data_core.skeleton_manager.set_joint_matrices(&handle, joint_matrices);
                 }
                 InstructionKind::AddDirectionalLight { handle, light } => {
-                    data_core.directional_light_manager.add(handle, light);
+                    data_core.directional_light_manager.add(&handle, light);
                 }
                 InstructionKind::ChangeDirectionalLight { handle, change } => {
-                    data_core.directional_light_manager.update(handle, change);
+                    data_core.directional_light_manager.update(&handle, change);
                 }
                 InstructionKind::AddPointLight { handle, light } => {
-                    data_core.point_light_manager.add(handle, light);
+                    data_core.point_light_manager.add(&handle, light);
                 }
                 InstructionKind::ChangePointLight { handle, change } => {
                     data_core.point_light_manager.update(handle, change);
@@ -150,40 +150,44 @@ pub fn evaluate_instructions(renderer: &Renderer) -> InstructionEvaluationOutput
                     );
                 }
                 InstructionKind::DeleteMesh { handle } => {
-                    renderer.resource_handle_allocators.mesh.deallocate(handle);
-                    renderer.mesh_manager.remove(handle)
+                    renderer.mesh_manager.remove(&handle);
+                    renderer.resource_handle_allocators.mesh.deallocate(handle);       // this finally consumes the handle.
+                    
                 }
-                InstructionKind::DeleteSkeleton { handle } => {
+                InstructionKind::DeleteSkeleton { handle } => {           
+                    data_core.skeleton_manager.remove(&renderer.mesh_manager, &handle);
                     renderer.resource_handle_allocators.skeleton.deallocate(handle);
-                    data_core.skeleton_manager.remove(&renderer.mesh_manager, handle)
                 }
-                InstructionKind::DeleteTexture2D { handle } => {
+                InstructionKind::DeleteTexture2D { handle } => {        
+                    data_core.d2_texture_manager.remove(&handle);
                     renderer.resource_handle_allocators.d2_texture.deallocate(handle);
-                    data_core.d2_texture_manager.remove(handle)
                 }
-                InstructionKind::DeleteTextureCube { handle } => {
+                InstructionKind::DeleteTextureCube { handle } => {                   
+                    data_core.d2c_texture_manager.remove(&handle);
                     renderer.resource_handle_allocators.d2c_texture.deallocate(handle);
-                    data_core.d2c_texture_manager.remove(handle)
                 }
-                InstructionKind::DeleteMaterial { handle } => {
+                InstructionKind::DeleteMaterial { handle } => {                    
+                    data_core.material_manager.remove(&handle);
                     renderer.resource_handle_allocators.material.deallocate(handle);
-                    data_core.material_manager.remove(handle)
                 }
-                InstructionKind::DeleteObject { handle } => {
+                InstructionKind::DeleteObject { handle } => {                   
+                    data_core.object_manager.remove(&handle);
                     renderer.resource_handle_allocators.object.deallocate(handle);
-                    data_core.object_manager.remove(handle)
                 }
                 InstructionKind::DeleteDirectionalLight { handle } => {
+                    data_core.directional_light_manager.remove(&handle);
                     renderer.resource_handle_allocators.directional_light.deallocate(handle);
-                    data_core.directional_light_manager.remove(handle)
+                    
                 }
                 InstructionKind::DeletePointLight { handle } => {
+                    data_core.point_light_manager.remove(&handle);
                     renderer.resource_handle_allocators.point_light.deallocate(handle);
-                    data_core.point_light_manager.remove(handle);
+                    
                 }
                 InstructionKind::DeleteGraphData { handle } => {
-                    renderer.resource_handle_allocators.graph_storage.deallocate(handle);
                     data_core.graph_storage.remove(&handle);
+                    renderer.resource_handle_allocators.graph_storage.deallocate(handle);
+                    
                 }
             }
         }

--- a/rend3/src/renderer/eval.rs
+++ b/rend3/src/renderer/eval.rs
@@ -10,7 +10,7 @@ use std::collections::{HashSet};
 
 /// Set to true to check instructions for deletion before use.
 /// This is a debug trap.
-const CHECK_INSTRUCTIONS: bool = true; // didn't fail in 20 hour test without mesh check
+const CHECK_INSTRUCTIONS: bool = true; // didn't fail in 20 hour test with this enabled.
 
 /// Instruction checker. Checks for instructions which delete an object preceding instructions which use that object.
 /// This is a debug trap for a race condition.
@@ -21,9 +21,9 @@ fn check_instructions(renderer: &Renderer, instructions: &Vec<Instruction>) {
     fn check_mesh_in_add_object(
         deleted_mesh_handles: &HashSet<usize>,
         object: &Object,
-        mesh_manager: &MeshManager,
+        _mesh_manager: &MeshManager,
     ) {
-        let mesh_manager_guard = mesh_manager.lock_internal_data();    // performance problem
+        //////let mesh_manager_guard = mesh_manager.lock_internal_data();    // performance problem
         match &object.mesh_kind {
             ObjectMeshKind::Animated(_skeleton) => {} // no check, because bug is in static meshes
             ObjectMeshKind::Static(mesh_handle) => {

--- a/rend3/src/renderer/eval.rs
+++ b/rend3/src/renderer/eval.rs
@@ -19,7 +19,7 @@ fn check_instructions(instructions: &Vec<Instruction>) {
     let mut deleted_handles = HashSet::new();
     for Instruction { kind, location : _} in instructions. iter() {
         match kind {
-            InstructionKind::AddObject { handle, object } => {
+            InstructionKind::AddObject { handle, .. } => {
                 //  Must not add a deleted object in the same pass.
                 if deleted_handles.contains(&handle.idx) {
                     panic!("Add of deleted object of object handle #{}", handle.idx);

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -243,7 +243,7 @@ impl Renderer {
             InstructionKind::AddMaterial {
                 handle: *handle,
                 fill_invoke: Box::new(move |material_manager, device, profile, d2_manager, mat_handle| {
-                    material_manager.add(device, profile, d2_manager, mat_handle, material)
+                    material_manager.add(device, profile, d2_manager, &mat_handle, material)
                 }),
             },
             *Location::caller(),
@@ -258,7 +258,7 @@ impl Renderer {
             InstructionKind::ChangeMaterial {
                 handle: **handle,
                 change_invoke: Box::new(move |material_manager, device, d2_manager, mat_handle| {
-                    material_manager.update(device, d2_manager, mat_handle, material)
+                    material_manager.update(device, d2_manager, &mat_handle, material)
                 }),
             },
             *Location::caller(),

--- a/rend3/src/renderer/mod.rs
+++ b/rend3/src/renderer/mod.rs
@@ -295,8 +295,9 @@ impl Renderer {
     /// Move the given object to a new transform location.
     #[track_caller]
     pub fn set_object_transform(&self, handle: &ObjectHandle, transform: Mat4) {
+        //  Note copy of raw handle, which will live as long as the instruction set.
         self.instructions
-            .push(InstructionKind::SetObjectTransform { handle: handle.get_raw(), transform }, *Location::caller());
+            .push(InstructionKind::SetObjectTransform { handle: *handle.get_raw(), transform }, *Location::caller());
     }
 
     /// Sets the joint positions for a skeleton. See
@@ -331,7 +332,7 @@ impl Renderer {
     #[track_caller]
     pub fn set_skeleton_joint_matrices(&self, handle: &SkeletonHandle, joint_matrices: Vec<Mat4>) {
         self.instructions.push(
-            InstructionKind::SetSkeletonJointDeltas { handle: handle.get_raw(), joint_matrices },
+            InstructionKind::SetSkeletonJointDeltas { handle: *handle.get_raw(), joint_matrices },
             *Location::caller(),
         )
     }
@@ -365,17 +366,18 @@ impl Renderer {
     }
 
     /// Updates the settings for given directional light.
-    #[track_caller]
+    #[track_caller] 
     pub fn update_directional_light(&self, handle: &DirectionalLightHandle, change: DirectionalLightChange) {
+        //  Note copy of raw handle, which will live as long as the instruction set.
         self.instructions
-            .push(InstructionKind::ChangeDirectionalLight { handle: handle.get_raw(), change }, *Location::caller())
+            .push(InstructionKind::ChangeDirectionalLight { handle: *handle.get_raw(), change }, *Location::caller())
     }
 
     /// Updates the settings for given point light.
     #[track_caller]
     pub fn update_point_light(&self, handle: &PointLightHandle, change: PointLightChange) {
         self.instructions
-            .push(InstructionKind::ChangePointLight { handle: handle.get_raw(), change }, *Location::caller())
+            .push(InstructionKind::ChangePointLight { handle: *handle.get_raw(), change }, *Location::caller())
     }
 
     /// Adds a piece of data for long term storage and convienient use in the RenderGraph

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -547,6 +547,7 @@ pub async fn create_iad(
                         label: None,
                         required_features: adapter.features.union(additional_features.unwrap_or_else(Features::empty)),
                         required_limits: adapter.limits,
+                        memory_hints: Default::default(), // Use default for memory hints for now. Possible future optimization.
                     },
                     None,
                 )

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -464,7 +464,7 @@ pub async fn create_iad(
     #[cfg(target_arch = "wasm32")]
     let default_backend_order = [Backend::BrowserWebGpu];
 
-    let instance = Instance::new(wgpu::InstanceDescriptor {
+    let instance = Instance::new(&wgpu::InstanceDescriptor {
         backends: backend_bits,
         dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
         gles_minor_version: Gles3MinorVersion::default(),

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -96,6 +96,10 @@ pub const GPU_REQUIRED_LIMITS: Limits = Limits {
     max_compute_workgroups_per_dimension: 65535,
     max_buffer_size: 8192 * 8 * 18,
     max_non_sampler_bindings: 1_000_000,
+    max_color_attachment_bytes_per_sample: 32, // From WGPU 0.20 (JN)
+    max_color_attachments: 8,
+    min_subgroup_size: 0,
+    max_subgroup_size: 0,
 };
 
 /// Limits required to run in the CpuDriven profile.
@@ -130,6 +134,10 @@ pub const CPU_REQUIRED_LIMITS: Limits = Limits {
     max_compute_workgroups_per_dimension: 65535,
     max_buffer_size: 8192 * 8 * 8,
     max_non_sampler_bindings: 1_000_000,
+    max_color_attachment_bytes_per_sample: 32, // From WGPU 0.20 (JN)
+    max_color_attachments: 8,
+    min_subgroup_size: 0,
+    max_subgroup_size: 0,
 };
 
 fn check_limit_unlimited<LimitValue: Into<u64> + Ord>(
@@ -311,6 +319,27 @@ pub fn check_limits(profile: RendererProfile, device_limits: &Limits) -> Result<
             LimitType::MaxBufferSize,
         )?,
         max_non_sampler_bindings: 1_000_000,
+        //  New in WGPU 0.20 (JN)
+        max_color_attachment_bytes_per_sample: check_limit_unlimited(
+            device_limits.max_color_attachment_bytes_per_sample,
+            required_limits.max_color_attachment_bytes_per_sample,
+            LimitType::MaxColorAttachmentBytesPerSample,
+        )?,
+        max_color_attachments: check_limit_unlimited(
+            device_limits.max_color_attachments,
+            required_limits.max_color_attachments,
+            LimitType::MaxColorAttachments,
+        )?,
+        max_subgroup_size: check_limit_unlimited(
+            device_limits.max_subgroup_size,
+            required_limits.max_subgroup_size,
+            LimitType::MaxSubgroupSize,
+        )?,
+        min_subgroup_size: check_limit_unlimited(
+            device_limits.min_subgroup_size,
+            required_limits.min_subgroup_size,
+            LimitType::MinSubgroupSize,
+        )?,
     })
 }
 

--- a/rend3/src/setup.rs
+++ b/rend3/src/setup.rs
@@ -466,8 +466,12 @@ pub async fn create_iad(
 
     let instance = Instance::new(&wgpu::InstanceDescriptor {
         backends: backend_bits,
-        dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
-        gles_minor_version: Gles3MinorVersion::default(),
+        //////dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
+        //////gles_minor_version: Gles3MinorVersion::default(),
+        backend_options: wgpu::BackendOptions { // per refactoring at WGPU
+            gl: wgpu::GlBackendOptions { gles_minor_version: Gles3MinorVersion::default()},
+            dx12: wgpu::Dx12BackendOptions { shader_compiler: wgpu::Dx12Compiler::Fxc, },
+        },
         flags: InstanceFlags::default(),
     });
 

--- a/rend3/src/util/freelist/vec.rs
+++ b/rend3/src/util/freelist/vec.rs
@@ -15,7 +15,7 @@ impl<T> FreelistVec<T> {
 
     pub fn push(&mut self, value: T) -> FreelistIndex {
         if let Some(index) = self.freelist.pop() {
-            debug_assert!(self.data[index].is_none());
+            assert!(self.data[index].is_none());    // Always check. It's cheap and race conditions have been found.
             self.data[index] = Some(value);
             FreelistIndex(index)
         } else {
@@ -26,7 +26,7 @@ impl<T> FreelistVec<T> {
     }
 
     pub fn remove(&mut self, index: FreelistIndex) {
-        debug_assert!(self.data[index.0].is_some());
+        assert!(self.data[index.0].is_some());  // Always check. It's cheap and race conditions have been found.
         self.data[index.0] = None;
         self.freelist.push(index.0);
     }

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -11,6 +11,7 @@ use wgpu::{
     PrimitiveTopology, RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline, RenderPipelineDescriptor,
     SamplerBindingType, SamplerDescriptor, ShaderModule, ShaderStages, StoreOp, Texture, TextureDescriptor,
     TextureSampleType, TextureViewDescriptor, TextureViewDimension, VertexState,
+    PipelineCompilationOptions,
 };
 
 use crate::{
@@ -115,7 +116,12 @@ impl MipmapGenerator {
         device.create_render_pipeline(&RenderPipelineDescriptor {
             label: Some(&label),
             layout: Some(pll),
-            vertex: VertexState { module: sm, entry_point: "vs_main", buffers: &[] },
+            vertex: VertexState { 
+                module: sm, 
+                entry_point: "vs_main", 
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+            },
             primitive: PrimitiveState {
                 topology: PrimitiveTopology::TriangleList,
                 strip_index_format: None,
@@ -131,6 +137,7 @@ impl MipmapGenerator {
                 module: sm,
                 entry_point: "fs_main",
                 targets: &[Some(ColorTargetState { format, blend: None, write_mask: ColorWrites::all() })],
+                compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
             }),
             multiview: None,
         })

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -139,6 +139,7 @@ impl MipmapGenerator {
                 compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             }),
             multiview: None,
+            cache: None,    // no pipeline cache. New in WGPU 21.
         })
     }
 

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -7,11 +7,10 @@ use thiserror::Error;
 use wgpu::{
     AddressMode, BindGroup, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, Color,
     ColorTargetState, ColorWrites, CommandEncoder, Device, FilterMode, FragmentState, FrontFace, LoadOp,
-    MultisampleState, Operations, PipelineLayout, PipelineLayoutDescriptor, PolygonMode, PrimitiveState,
-    PrimitiveTopology, RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline, RenderPipelineDescriptor,
-    SamplerBindingType, SamplerDescriptor, ShaderModule, ShaderStages, StoreOp, Texture, TextureDescriptor,
-    TextureSampleType, TextureViewDescriptor, TextureViewDimension, VertexState,
-    PipelineCompilationOptions,
+    MultisampleState, Operations, PipelineCompilationOptions, PipelineLayout, PipelineLayoutDescriptor, PolygonMode,
+    PrimitiveState, PrimitiveTopology, RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline,
+    RenderPipelineDescriptor, SamplerBindingType, SamplerDescriptor, ShaderModule, ShaderStages, StoreOp, Texture,
+    TextureDescriptor, TextureSampleType, TextureViewDescriptor, TextureViewDimension, VertexState,
 };
 
 use crate::{
@@ -116,11 +115,11 @@ impl MipmapGenerator {
         device.create_render_pipeline(&RenderPipelineDescriptor {
             label: Some(&label),
             layout: Some(pll),
-            vertex: VertexState { 
-                module: sm, 
-                entry_point: "vs_main", 
+            vertex: VertexState {
+                module: sm,
+                entry_point: "vs_main",
                 buffers: &[],
-                compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+                compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             },
             primitive: PrimitiveState {
                 topology: PrimitiveTopology::TriangleList,
@@ -137,7 +136,7 @@ impl MipmapGenerator {
                 module: sm,
                 entry_point: "fs_main",
                 targets: &[Some(ColorTargetState { format, blend: None, write_mask: ColorWrites::all() })],
-                compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+                compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             }),
             multiview: None,
         })

--- a/rend3/src/util/mipmap.rs
+++ b/rend3/src/util/mipmap.rs
@@ -117,7 +117,7 @@ impl MipmapGenerator {
             layout: Some(pll),
             vertex: VertexState {
                 module: sm,
-                entry_point: "vs_main",
+                entry_point: Some("vs_main"),
                 buffers: &[],
                 compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             },
@@ -134,7 +134,7 @@ impl MipmapGenerator {
             multisample: MultisampleState::default(),
             fragment: Some(FragmentState {
                 module: sm,
-                entry_point: "fs_main",
+                entry_point: Some("fs_main"),
                 targets: &[Some(ColorTargetState { format, blend: None, write_mask: ColorWrites::all() })],
                 compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             }),

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -162,6 +162,7 @@ mod test {
                     label: None,
                     required_features: wgpu::Features::empty(),
                     required_limits: wgpu::Limits::default(),
+                    memory_hints: wgpu::MemoryHints::default(),
                 },
                 None,
             ))

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -61,7 +61,7 @@ impl ScatterCopy {
             label: Some("ScatterCopy compute pipeline"),
             layout: Some(&pll),
             module: &sm,
-            entry_point: "cs_main",
+            entry_point: Some("cs_main"),
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
             cache: None, // no pipeline cache. New in WGPU 21
         });

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -63,6 +63,7 @@ impl ScatterCopy {
             module: &sm,
             entry_point: "cs_main",
             compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
+            cache: None, // no pipeline cache. New in WGPU 21
         });
 
         Self { pipeline, bgl }

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -113,7 +113,9 @@ impl ScatterCopy {
             mapped_slice[range_start] = item.word_offset;
             let mut writer = encase::internal::Writer::new(
                 &item.data,
-                bytemuck::cast_slice_mut(&mut mapped_slice[range_start + 1..range_end]),
+                //////bytemuck::cast_slice_mut(&mut mapped_slice[range_start + 1..range_end]),
+                bytemuck::cast_slice_mut::<_, u8>(&mut mapped_slice[range_start + 1..range_end]),
+                ////bytemuck::cast_slice_mut::<_, encase::internal::BufferMut>(&mut mapped_slice[range_start + 1..range_end]),
                 0,
             )
             .unwrap();

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -4,6 +4,7 @@ use encase::{private::WriteInto, ShaderSize};
 use wgpu::{
     BindGroupLayout, BindingType, Buffer, BufferBindingType, BufferDescriptor, BufferUsages, CommandEncoder,
     ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, Device, PipelineLayoutDescriptor, ShaderStages,
+    PipelineCompilationOptions,
 };
 
 use crate::util::{
@@ -61,6 +62,7 @@ impl ScatterCopy {
             layout: Some(&pll),
             module: &sm,
             entry_point: "cs_main",
+            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
         });
 
         Self { pipeline, bgl }

--- a/rend3/src/util/scatter_copy.rs
+++ b/rend3/src/util/scatter_copy.rs
@@ -3,8 +3,8 @@ use std::num::NonZeroU64;
 use encase::{private::WriteInto, ShaderSize};
 use wgpu::{
     BindGroupLayout, BindingType, Buffer, BufferBindingType, BufferDescriptor, BufferUsages, CommandEncoder,
-    ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, Device, PipelineLayoutDescriptor, ShaderStages,
-    PipelineCompilationOptions,
+    ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, Device, PipelineCompilationOptions,
+    PipelineLayoutDescriptor, ShaderStages,
 };
 
 use crate::util::{
@@ -62,7 +62,7 @@ impl ScatterCopy {
             layout: Some(&pll),
             module: &sm,
             entry_point: "cs_main",
-            compilation_options: PipelineCompilationOptions::default(),    // use default WGPU options. New in WGPU 0.20 (JN)
+            compilation_options: PipelineCompilationOptions::default(), // use default WGPU options. New in WGPU 0.20 (JN)
         });
 
         Self { pipeline, bgl }


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate/complete your PR -->

## Checklist

- CI Checked:
  - [ ] `cargo fmt` has been ran
  - [ ] `cargo clippy` reports no issues
  - [ ] `cargo test` succeeds
  - [ ] `cargo rend3-doc` has no warnings
  - [ ] `cargo deny check` issues have been fixed or added to deny.toml
- Manually Checked:
  - [x ] relevant examples/test cases run
  - [x ] changes added to changelog
    - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Related Issues

## Description
Bring Rend3 up to date with current **wgpu** (0.20), **egui**, and **winit**.

Fix outstanding warning messages.

Advance version to 0.20.0 to match **wgpu**. Intent is to follow **wgpu** version from now on when possible. After testing, this version should be pushed to "crates.io" as version 0.20.0.
